### PR TITLE
Update docs for standalone repo and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides context for Claude Code when working on this project.
+
+## Project Overview
+
+Fitness API is a Python backend for analyzing and aggregating running data from multiple sources:
+- **Strava**: Outdoor runs via OAuth API integration
+- **MapMyFitness**: Historical/treadmill runs via CSV upload
+
+The frontend dashboard is a separate project and not included in this repository.
+
+## Tech Stack
+
+- **FastAPI** - REST API framework
+- **PostgreSQL** - Database (Neon DB in production)
+- **psycopg3** - Raw SQL (no ORM)
+- **Alembic** - Database migrations
+- **Pydantic** - Data validation
+- **uv** - Package management
+
+## Key Commands
+
+```bash
+# Install dependencies
+uv sync
+
+# Run dev server
+make dev
+
+# Run tests
+make test          # Unit tests only (fast)
+make e2e-test      # E2E tests with Postgres container (requires Docker)
+make int-test      # Integration tests (requires Strava credentials)
+make all-test      # All tests
+
+# Code quality
+make lint          # Run ruff linter
+make format        # Format with ruff
+make ty            # Type checking
+
+# Database
+uv run alembic upgrade head              # Run migrations
+uv run alembic revision -m "message"     # Create new migration
+```
+
+## Directory Structure
+
+```
+fitness/
+├── app/           # FastAPI app, routes, auth
+│   └── routers/   # API endpoint handlers
+├── db/            # Database layer (raw SQL queries)
+├── models/        # Pydantic models
+├── agg/           # Aggregation logic (metrics calculations)
+├── load/          # Data loading (Strava, MMF)
+├── integrations/  # External service clients (Strava, Google)
+└── utils/         # Utilities
+
+tests/
+├── app/           # API tests
+├── db/            # Database tests
+├── e2e/           # End-to-end tests (require Docker)
+├── integrations/  # Integration tests
+└── _factories/    # Test data factories
+```
+
+## Architecture Patterns
+
+### Database Layer
+- **Raw SQL via psycopg3** - No ORM, direct queries in `fitness/db/`
+- **Context managers** - Connection management with automatic cleanup
+- **Deterministic IDs** - Strava runs: `strava_{id}`, MMF runs: `mmf_{id}`, Shoes: normalized name
+
+### Data Patterns
+- **Soft deletion** - `deleted_at` field, records preserved for audit
+- **Version tracking** - `runs_history` table tracks all edits
+- **Upsert operations** - Safe re-imports without duplicates
+
+### Authentication
+- OAuth 2.0 via external identity provider
+- Bearer tokens for mutation endpoints (POST/PATCH/DELETE)
+- Read endpoints (GET) are public
+
+## Environment Variables
+
+Key variables (see `.env.dev.example`):
+- `DATABASE_URL` - PostgreSQL connection string
+- `STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET`, `STRAVA_REFRESH_TOKEN`
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` (optional, for calendar sync)
+- `IDENTITY_PROVIDER_URL` - OAuth provider base URL
+
+## Testing Notes
+
+- Unit tests are fast and require no external services
+- E2E tests use testcontainers (Docker) for PostgreSQL
+- Integration tests require valid Strava credentials in `.env.dev`
+- Test factories in `tests/_factories/` generate consistent test data

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -7,7 +7,7 @@
 
 ## Environment Setup
 
-All of your `.env` files should be in `api` directory and contain the following:
+All of your `.env` files should be in the project root directory and contain the following:
 
 ```env
 # Database connection
@@ -29,16 +29,14 @@ postgresql://[username[:password]@][host[:port]][/database]
 ### 1. Install Dependencies
 
 ```bash
-cd api
 uv sync
 ```
 
 ### 2. Run Migrations
 
-Assuming your database is already created, you can run the migrations with the following commands:
+Assuming your database is already created, you can run the migrations with the following command:
 
 ```bash
-cd api
 uv run alembic upgrade head
 ```
 
@@ -302,7 +300,7 @@ The API provides REST endpoints for run editing:
 
 For new installations:
 
-1. **Schema Migration**: Run `alembic upgrade head` to create all required tables including `runs_history`
+1. **Schema Migration**: Run `uv run alembic upgrade head` to create all required tables including `runs_history`
 2. **Automatic History**: All newly imported runs will automatically get their original history entries created during import
 
 ## Creating New Migrations
@@ -310,14 +308,13 @@ For new installations:
 When you need to modify the database schema:
 
 ```bash
-cd api
-alembic revision -m "Description of your change"
+uv run alembic revision -m "Description of your change"
 ```
 
 Edit the generated migration file in `alembic/versions/`, then apply it:
 
 ```bash
-alembic upgrade head
+uv run alembic upgrade head
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Remove outdated `api/` directory references throughout docs (project is now standalone, not a subdirectory)
- Clarify that the frontend dashboard is a separate project
- Replace reference to nonexistent `scripts/get_strava_tokens.py` with actual manual OAuth instructions
- Add `uv run` prefix to alembic commands for consistency
- Add `CLAUDE.md` with project context for Claude Code

## Test plan
- [ ] Verify README.md instructions are accurate for the standalone repo structure
- [ ] Verify DATABASE.md migration commands work from project root
- [ ] Review CLAUDE.md for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)