### PR TITLE
Fix E2E tests to use OAuth/JWT authentication

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,5 +1,7 @@
 import os
 from pathlib import Path
+from uuid import UUID
+from datetime import datetime, timezone
 from typing import Iterator
 import pytest
 from testcontainers.postgres import PostgresContainer
@@ -7,8 +9,28 @@ from alembic.config import Config
 from alembic import command
 from fastapi.testclient import TestClient
 
+from fitness.models.user import User, Role
+
 # Ensure allowed environment for env_loader
 os.environ.setdefault("ENV", "dev")
+
+
+# Shared test user data
+TEST_USER_ID = UUID("00000000-0000-0000-0000-000000000001")
+TEST_IDP_USER_ID = UUID("00000000-0000-0000-0000-000000000002")
+
+
+def _create_test_user(role: Role = "viewer") -> User:
+    """Create a test user with specified role."""
+    return User(
+        id=TEST_USER_ID,
+        idp_user_id=TEST_IDP_USER_ID,
+        email="e2e_test@example.com",
+        username="e2e_test_user",
+        role=role,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -29,24 +51,80 @@ def db_url() -> Iterator[str]:
 
 
 @pytest.fixture(scope="session")
-def client(db_url: str) -> TestClient:
-    """Create a FastAPI TestClient after DB is configured."""
+def _mock_oauth(db_url: str) -> Iterator[None]:
+    """Session-scoped OAuth mocking for E2E tests.
+
+    Sets up mocks that accept both viewer and editor tokens.
+    Must depend on db_url to ensure DB is ready before app imports.
+    """
+    # Import oauth module after db_url fixture sets DATABASE_URL
+    from fitness.app import oauth
+
+    original_validate = oauth.validate_jwt_token
+    original_get_or_create = oauth.get_or_create_user
+
+    def mock_validate(token: str) -> dict[str, str] | None:
+        if token == "viewer_token":
+            return {
+                "username": "e2e_viewer",
+                "email": "viewer@example.com",
+                "sub": str(TEST_IDP_USER_ID),
+            }
+        if token == "editor_token":
+            return {
+                "username": "e2e_editor",
+                "email": "editor@example.com",
+                "sub": str(TEST_IDP_USER_ID),
+            }
+        return None
+
+    def mock_get_or_create_user(
+        idp_user_id: UUID, email: str | None, username: str | None
+    ) -> User:
+        # Determine role based on username from the token
+        if username == "e2e_editor":
+            return _create_test_user(role="editor")
+        return _create_test_user(role="viewer")
+
+    oauth.validate_jwt_token = mock_validate  # type: ignore[assignment]
+    oauth.get_or_create_user = mock_get_or_create_user  # type: ignore[assignment]
+
+    yield
+
+    oauth.validate_jwt_token = original_validate
+    oauth.get_or_create_user = original_get_or_create
+
+
+@pytest.fixture(scope="session")
+def client(db_url: str, _mock_oauth: None) -> TestClient:
+    """Unauthenticated test client (for testing auth requirements)."""
     from fitness.app.app import app
 
     return TestClient(app)
 
 
 @pytest.fixture(scope="session")
-def auth_client(db_url: str) -> TestClient:
-    """Create an authenticated FastAPI TestClient after DB is configured."""
+def viewer_client(db_url: str, _mock_oauth: None) -> TestClient:
+    """Test client with viewer role authentication."""
     from fitness.app.app import app
 
-    # Set default auth credentials if not already set
-    user = os.environ.get("BASIC_AUTH_USERNAME", "testuser")
-    password = os.environ.get("BASIC_AUTH_PASSWORD", "testpass")
-    os.environ.setdefault("BASIC_AUTH_USERNAME", user)
-    os.environ.setdefault("BASIC_AUTH_PASSWORD", password)
+    client = TestClient(app)
+    client.headers = {"Authorization": "Bearer viewer_token"}
+    return client
+
+
+@pytest.fixture(scope="session")
+def editor_client(db_url: str, _mock_oauth: None) -> TestClient:
+    """Test client with editor role authentication."""
+    from fitness.app.app import app
 
     client = TestClient(app)
-    client.auth = (user, password)
+    client.headers = {"Authorization": "Bearer editor_token"}
     return client
+
+
+# Backwards compatibility alias
+@pytest.fixture(scope="session")
+def auth_client(editor_client: TestClient) -> TestClient:
+    """Alias for editor_client for backwards compatibility."""
+    return editor_client

--- a/tests/e2e/test_run_details_endpoint.py
+++ b/tests/e2e/test_run_details_endpoint.py
@@ -11,7 +11,7 @@ from fitness.models.shoe import generate_shoe_id
 
 
 @pytest.mark.e2e
-def test_run_details_basic_and_shoe_notes(client):
+def test_run_details_basic_and_shoe_notes(viewer_client):
     """Create a run with a shoe and verify details and shoe retirement notes appear."""
     # Use a far-future date to avoid collisions with other e2e runs
     run = Run(
@@ -39,7 +39,7 @@ def test_run_details_basic_and_shoe_notes(client):
     assert retired is True
 
     # Fetch details without date filter (endpoint defaults include all)
-    res = client.get("/runs/details")
+    res = viewer_client.get("/runs/details")
     assert res.status_code == 200
     details = res.json()
 
@@ -68,7 +68,7 @@ def test_run_details_basic_and_shoe_notes(client):
 
 
 @pytest.mark.e2e
-def test_run_details_with_sync_and_date_filtering_and_sorting(client):
+def test_run_details_with_sync_and_date_filtering_and_sorting(viewer_client):
     """Verify sync fields, date filtering, and sorting behavior."""
     run_a = Run(
         id="details_test_run_2A",
@@ -103,7 +103,7 @@ def test_run_details_with_sync_and_date_filtering_and_sorting(client):
     assert sync.google_event_id == "evt_details_sync_123"
 
     # Filter to a narrow range containing only run_b
-    res = client.get(
+    res = viewer_client.get(
         "/runs/details", params={"start": "2035-02-04", "end": "2035-02-06"}
     )
     assert res.status_code == 200
@@ -124,7 +124,7 @@ def test_run_details_with_sync_and_date_filtering_and_sorting(client):
     assert run_b_item["version"] >= 1
 
     # Now query a broader range that includes both and test sorting by distance asc
-    res = client.get(
+    res = viewer_client.get(
         "/runs/details",
         params={
             "start": "2035-02-01",


### PR DESCRIPTION
## Summary
- Rewrite `tests/e2e/conftest.py` to mock OAuth/JWT authentication (matching unit test pattern)
- Add `viewer_client` and `editor_client` fixtures with proper role-based auth
- Update all E2E tests to use authenticated clients for read/write operations

## Background
The E2E tests were using an outdated basic auth mechanism (`BASIC_AUTH_USERNAME`/`BASIC_AUTH_PASSWORD`) while the app uses OAuth/JWT. This caused 21 of 49 E2E tests to fail with 401 errors.

## Test plan
- [x] All 237 tests pass (`make all-test`)
- [x] E2E tests specifically pass (`make e2e-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)