### PR TITLE
Add safety fixture to prevent accidental DB access in unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,42 @@ from fitness.app import env_loader  # noqa: F401
 from ._factories import RunFactory, StravaActivityWithGearFactory, MmfActivityFactory
 
 
+class AccidentalDatabaseAccessError(Exception):
+    """Raised when a unit test accidentally tries to access the database."""
+
+    pass
+
+
+def _raise_db_access_error(*args, **kwargs):
+    """Raise an error when DB access is attempted in unit tests."""
+    raise AccidentalDatabaseAccessError(
+        "Unit test attempted to connect to the database! "
+        "Either mock the database call with @patch('fitness.db.connection.get_db_cursor') "
+        "or similar, or mark this test as @pytest.mark.e2e if it requires real DB access."
+    )
+
+
+@pytest.fixture(autouse=True)
+def prevent_db_access_in_unit_tests(request, monkeypatch):
+    """Prevent accidental database access in unit tests.
+
+    This fixture automatically applies to all tests. For e2e tests (marked with
+    @pytest.mark.e2e), it does nothing. For all other tests, it patches psycopg.connect
+    to raise a clear error if any code path tries to access the database without
+    proper mocking.
+
+    This catches issues early when someone forgets to mock a DB call in a unit test.
+    """
+    # Skip this protection for e2e tests - they need real DB access
+    if "e2e" in [marker.name for marker in request.node.iter_markers()]:
+        yield
+        return
+
+    # For unit tests, patch psycopg.connect to fail fast with a clear error
+    monkeypatch.setattr("psycopg.connect", _raise_db_access_error)
+    yield
+
+
 @pytest.fixture(scope="session")
 def run_factory() -> RunFactory:
     return RunFactory()


### PR DESCRIPTION
## Summary
- Adds an autouse fixture to `tests/conftest.py` that patches `psycopg.connect` to raise a clear error if any unit test accidentally tries to connect to the database without proper mocking
- E2E tests (marked with `@pytest.mark.e2e`) bypass this protection and can access the real database

## Motivation
If someone writes a unit test that forgets to mock a DB call, CI would previously fail with a confusing "connection refused" error. Now it fails fast with a clear message explaining how to fix it:

```
AccidentalDatabaseAccessError: Unit test attempted to connect to the database!
Either mock the database call with @patch('fitness.db.connection.get_db_cursor')
or similar, or mark this test as @pytest.mark.e2e if it requires real DB access.
```

## Test plan
- [x] All 216 unit tests pass
- [x] All 21 e2e tests pass (they bypass the safety fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)