### PR TITLE
Make max_pace and max_speed optional in MMF activity model

### DIFF
--- a/fitness/load/mmf/models.py
+++ b/fitness/load/mmf/models.py
@@ -72,14 +72,14 @@ class MmfActivity(BaseModel):
     avg_pace: float = Field(
         validation_alias=AliasChoices("avg_pace", "Avg Pace (min/mi)")
     )
-    max_pace: float = Field(
-        validation_alias=AliasChoices("max_pace", "Max Pace (min/mi)")
+    max_pace: Annotated[float | None, BeforeValidator(empty_str_to_none)] = Field(
+        validation_alias=AliasChoices("max_pace", "Max Pace (min/mi)"),
     )
     avg_speed: float = Field(
         validation_alias=AliasChoices("avg_speed", "Avg Speed (mi/h)")
     )
-    max_speed: float = Field(
-        validation_alias=AliasChoices("max_speed", "Max Speed (mi/h)")
+    max_speed: Annotated[float | None, BeforeValidator(empty_str_to_none)] = Field(
+        validation_alias=AliasChoices("max_speed", "Max Speed (mi/h)"),
     )
     avg_heart_rate: Annotated[float | None, BeforeValidator(empty_str_to_none)] = Field(
         validation_alias=AliasChoices("avg_heart_rate", "Avg Heart Rate"),


### PR DESCRIPTION
## Summary
- Makes `max_pace` and `max_speed` optional (`float | None`) in the `MmfActivity` model
- These fields are not stored in the database or used downstream, so allowing them to be empty/missing prevents unnecessary parse failures during CSV import

## Test plan
- [ ] Verify existing tests pass
- [ ] Upload MMF CSV with missing max_pace/max_speed values parses successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)