### PR TITLE
Run ruff format on unformatted files

### DIFF
--- a/alembic/versions/a5f9c60f97e4_add_run_workouts_table_and_runs_fk.py
+++ b/alembic/versions/a5f9c60f97e4_add_run_workouts_table_and_runs_fk.py
@@ -5,14 +5,15 @@ Revises: fb8efa3c6e02
 Create Date: 2026-01-31 01:17:57.872244+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'a5f9c60f97e4'
-down_revision: Union[str, Sequence[str], None] = 'fb8efa3c6e02'
+revision: str = "a5f9c60f97e4"
+down_revision: Union[str, Sequence[str], None] = "fb8efa3c6e02"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/fitness/app/routers/run_workouts.py
+++ b/fitness/app/routers/run_workouts.py
@@ -147,7 +147,9 @@ async def get_workout(
     """Get a single run workout with full details and nested runs."""
     workout = get_run_workout_by_id(workout_id)
     if workout is None:
-        raise HTTPException(status_code=404, detail=f"Run workout {workout_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Run workout {workout_id} not found"
+        )
     return _build_workout_detail_response(workout)
 
 
@@ -167,7 +169,9 @@ async def patch_workout(
         notes=request.notes,
     )
     if workout is None:
-        raise HTTPException(status_code=404, detail=f"Run workout {workout_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Run workout {workout_id} not found"
+        )
     return _build_workout_detail_response(workout)
 
 
@@ -185,7 +189,9 @@ async def replace_workout_runs(
 
     workout = get_run_workout_by_id(workout_id)
     if workout is None:
-        raise HTTPException(status_code=404, detail=f"Run workout {workout_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Run workout {workout_id} not found"
+        )
     return _build_workout_detail_response(workout)
 
 
@@ -197,7 +203,9 @@ async def remove_workout(
     """Soft-delete a run workout and unlink its runs."""
     deleted = delete_run_workout(workout_id)
     if not deleted:
-        raise HTTPException(status_code=404, detail=f"Run workout {workout_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Run workout {workout_id} not found"
+        )
     return {"message": f"Run workout {workout_id} deleted"}
 
 

--- a/fitness/db/run_workouts.py
+++ b/fitness/db/run_workouts.py
@@ -176,9 +176,7 @@ def set_run_workout_runs(workout_id: str, run_ids: list[str]) -> None:
                     raise ValueError(f"Run workout {workout_id} not found")
 
                 # Validate new run IDs (exclude runs currently in THIS workout)
-                _validate_run_ids(
-                    cursor, run_ids, exclude_workout_id=workout_id
-                )
+                _validate_run_ids(cursor, run_ids, exclude_workout_id=workout_id)
 
                 # Clear existing associations
                 cursor.execute(
@@ -287,9 +285,7 @@ def _validate_run_ids(
         )
 
 
-def _assign_runs_to_workout(
-    cursor, workout_id: str, run_ids: list[str]
-) -> None:
+def _assign_runs_to_workout(cursor, workout_id: str, run_ids: list[str]) -> None:
     """Set run_workout_id on the given runs."""
     from psycopg import sql
 


### PR DESCRIPTION
## Summary
- Runs `ruff format` on 3 files that were not properly formatted after the RunWorkout feature merge

## Test plan
- [x] All 301 unit tests pass
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)