### PR TITLE
Add default=None to max_pace and max_speed fields

### DIFF
--- a/fitness/load/mmf/models.py
+++ b/fitness/load/mmf/models.py
@@ -73,12 +73,14 @@ class MmfActivity(BaseModel):
         validation_alias=AliasChoices("avg_pace", "Avg Pace (min/mi)")
     )
     max_pace: Annotated[float | None, BeforeValidator(empty_str_to_none)] = Field(
+        default=None,
         validation_alias=AliasChoices("max_pace", "Max Pace (min/mi)"),
     )
     avg_speed: float = Field(
         validation_alias=AliasChoices("avg_speed", "Avg Speed (mi/h)")
     )
     max_speed: Annotated[float | None, BeforeValidator(empty_str_to_none)] = Field(
+        default=None,
         validation_alias=AliasChoices("max_speed", "Max Speed (mi/h)"),
     )
     avg_heart_rate: Annotated[float | None, BeforeValidator(empty_str_to_none)] = Field(


### PR DESCRIPTION
## Summary
- Adds `default=None` to `max_pace` and `max_speed` in `MmfActivity` so CSV imports work when the columns are missing entirely
- Without a default, Pydantic treats the fields as required-but-nullable, causing validation errors on rows missing these columns

## Test plan
- [x] Unit tests pass locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)