### PR TITLE
Switch from raw TRIMP to hrTSS for training load

### DIFF
--- a/fitness/agg/training_load.py
+++ b/fitness/agg/training_load.py
@@ -7,9 +7,9 @@ from fitness.models import Run, DayTrainingLoad, TrainingLoad, Sex
 from fitness.utils.timezone import convert_runs_to_user_timezone
 
 
-class DayTrimp(NamedTuple):
+class DayHrtss(NamedTuple):
     date: date
-    trimp: float
+    hrtss: float
 
 
 ATL_LOOKBACK = 7
@@ -41,6 +41,35 @@ def trimp(run: Run, max_hr: float, resting_hr: float, sex: Sex) -> float:
     return duration_minutes * hr_relative * y
 
 
+def threshold_trimp(max_hr: float, resting_hr: float, lthr: float, sex: Sex) -> float:
+    """Calculate the TRIMP for a hypothetical 60-minute run at lactate threshold heart rate.
+
+    This serves as the normalization reference for hrTSS: 1 hour at LTHR = 100 hrTSS.
+    """
+    hr_relative = (lthr - resting_hr) / (max_hr - resting_hr)
+    hr_relative = max(0.0, min(1.0, hr_relative))
+    match sex:
+        case "M":
+            y = 0.64 * math.exp(1.92 * hr_relative)
+        case "F":
+            y = 0.86 * math.exp(1.67 * hr_relative)
+    return 60.0 * hr_relative * y
+
+
+def hrtss(run: Run, max_hr: float, resting_hr: float, lthr: float, sex: Sex) -> float:
+    """Calculate Heart Rate Training Stress Score for a run.
+
+    hrTSS = (activity_TRIMP / threshold_TRIMP) * 100
+
+    A 60-minute run at LTHR produces hrTSS ≈ 100.
+    """
+    activity_trimp = trimp(run, max_hr, resting_hr, sex)
+    thr_trimp = threshold_trimp(max_hr, resting_hr, lthr, sex)
+    if thr_trimp == 0:
+        return 0.0
+    return (activity_trimp / thr_trimp) * 100.0
+
+
 def _exponential_training_load(trimp_values: list[float], tau: int) -> list[float]:
     alpha = 1 - math.exp(-1 / tau)
     load = []
@@ -69,6 +98,7 @@ def training_stress_balance(
     runs: list[Run],
     max_hr: float,
     resting_hr: float,
+    lthr: float,
     sex: Sex,
     start_date: date,
     end_date: date,
@@ -77,10 +107,14 @@ def training_stress_balance(
     """
     Calculate Training Stress Balance (TSB) as the difference between CTL and ATL.
 
+    ATL, CTL, and TSB are computed from daily hrTSS values (TRIMP normalized so
+    that 1 hour at LTHR = 100).
+
     Args:
         runs: List of runs (with UTC dates)
         max_hr: Maximum heart rate
         resting_hr: Resting heart rate
+        lthr: Lactate threshold heart rate
         sex: Sex ("M" or "F")
         start_date: Start date in user's timezone
         end_date: End date in user's timezone
@@ -92,23 +126,23 @@ def training_stress_balance(
     # Convert runs to user timezone if specified
     user_tz_runs = convert_runs_to_user_timezone(hr_runs, user_timezone)
 
-    trimp_by_date: list[tuple[date, float]] = []
+    hrtss_by_date: list[tuple[date, float]] = []
 
     # Handle empty runs case
     if not user_tz_runs:
         # Return zero values for each day in the requested range
         current_date = start_date
         while current_date <= end_date:
-            trimp_by_date.append((current_date, 0.0))
+            hrtss_by_date.append((current_date, 0.0))
             current_date += timedelta(days=1)
-        atl = [0.0] * len(trimp_by_date)
-        ctl = [0.0] * len(trimp_by_date)
-        tsb = [0.0] * len(trimp_by_date)
-        dates = [dt for dt, _ in trimp_by_date]
-        trimp_values = [tr for _, tr in trimp_by_date]
+        atl = [0.0] * len(hrtss_by_date)
+        ctl = [0.0] * len(hrtss_by_date)
+        tsb = [0.0] * len(hrtss_by_date)
+        dates = [dt for dt, _ in hrtss_by_date]
+        hrtss_values = [h for _, h in hrtss_by_date]
         return [
-            DayTrainingLoad(date=d, training_load=TrainingLoad(ctl=c, atl=a, tsb=t, trimp=tr))
-            for (d, c, a, t, tr) in zip(dates, ctl, atl, tsb, trimp_values)
+            DayTrainingLoad(date=d, training_load=TrainingLoad(ctl=c, atl=a, tsb=t, hrtss=h))
+            for (d, c, a, t, h) in zip(dates, ctl, atl, tsb, hrtss_values)
         ]
 
     # Always start calculations from the beginning of running data, because these metrics converge over time.
@@ -121,30 +155,31 @@ def training_stress_balance(
             for localized_run in user_tz_runs
             if localized_run.local_date == current_date
         ]
-        trimp_values = [trimp(run, max_hr, resting_hr, sex) for run in runs_for_day]
-        trimp_by_date.append((current_date, sum(trimp_values, start=0.0)))
-    atl, ctl = _calculate_atl_and_ctl([trimp for _, trimp in trimp_by_date])
+        day_hrtss_values = [hrtss(run, max_hr, resting_hr, lthr, sex) for run in runs_for_day]
+        hrtss_by_date.append((current_date, sum(day_hrtss_values, start=0.0)))
+    atl, ctl = _calculate_atl_and_ctl([h for _, h in hrtss_by_date])
     tsb = [ctl_value - atl_value for ctl_value, atl_value in zip(ctl, atl)]
-    dates = [dt for dt, _ in trimp_by_date]
-    trimp_values = [tr for _, tr in trimp_by_date]
+    dates = [dt for dt, _ in hrtss_by_date]
+    hrtss_values = [h for _, h in hrtss_by_date]
     return [
-        DayTrainingLoad(date=d, training_load=TrainingLoad(ctl=c, atl=a, tsb=t, trimp=tr))
-        for (d, c, a, t, tr) in zip(dates, ctl, atl, tsb, trimp_values)
+        DayTrainingLoad(date=d, training_load=TrainingLoad(ctl=c, atl=a, tsb=t, hrtss=h))
+        for (d, c, a, t, h) in zip(dates, ctl, atl, tsb, hrtss_values)
         if start_date <= d <= end_date
     ]
 
 
-def trimp_by_day(
+def hrtss_by_day(
     runs: list[Run],
     start: date,
     end: date,
     max_hr: float,
     resting_hr: float,
+    lthr: float,
     sex: Sex,
     user_timezone: str | None = None,
-) -> list[DayTrimp]:
+) -> list[DayHrtss]:
     """
-    Calculate TRIMP values for each day in the date range.
+    Calculate hrTSS values for each day in the date range.
 
     Args:
         runs: List of runs (with UTC dates)
@@ -152,6 +187,7 @@ def trimp_by_day(
         end: End date in user's timezone
         max_hr: Maximum heart rate
         resting_hr: Resting heart rate
+        lthr: Lactate threshold heart rate
         sex: Sex ("M" or "F")
         user_timezone: User's timezone (e.g., "America/Chicago"). If None, uses UTC dates.
     """
@@ -167,17 +203,17 @@ def trimp_by_day(
         if start <= localized_run.local_date <= end:
             runs_by_date[localized_run.local_date].append(localized_run)
 
-    # Calculate TRIMP for each day
-    day_trimps = []
+    # Calculate hrTSS for each day
+    day_hrtss_list = []
     current_date = start
     while current_date <= end:
         day_runs = runs_by_date[current_date]
-        daily_trimp = 0.0
+        daily_hrtss = 0.0
 
         for run in day_runs:
-            daily_trimp += trimp(run, max_hr, resting_hr, sex)
+            daily_hrtss += hrtss(run, max_hr, resting_hr, lthr, sex)
 
-        day_trimps.append(DayTrimp(date=current_date, trimp=daily_trimp))
+        day_hrtss_list.append(DayHrtss(date=current_date, hrtss=daily_hrtss))
         current_date += timedelta(days=1)
 
-    return day_trimps
+    return day_hrtss_list

--- a/fitness/app/routers/metrics.py
+++ b/fitness/app/routers/metrics.py
@@ -12,7 +12,7 @@ from fitness.agg import (
 )
 from fitness.db.runs import get_runs_for_date_range, get_all_runs
 from fitness.db.shoes import get_shoes
-from fitness.agg.training_load import trimp_by_day
+from fitness.agg.training_load import hrtss_by_day
 from fitness.app.constants import DEFAULT_START, DEFAULT_END
 from fitness.app.auth import require_viewer
 from fitness.models import Sex, DayTrainingLoad, ShoeMileage, User
@@ -124,13 +124,14 @@ def read_training_load_by_day(
     end: date,
     max_hr: float,
     resting_hr: float,
+    lthr: float,
     sex: Sex,
     user_timezone: str | None = None,
     _user: User = Depends(require_viewer),
 ) -> list[DayTrainingLoad]:
     """Get training load by day.
 
-    Computes CTL/ATL/TSB over the specified range using heart-rate-enabled runs.
+    Computes CTL/ATL/TSB over the specified range using hrTSS (heart-rate-enabled runs).
     Needs full history for ATL/CTL convergence.
     """
     runs = get_all_runs()
@@ -138,6 +139,7 @@ def read_training_load_by_day(
         runs=runs,
         max_hr=max_hr,
         resting_hr=resting_hr,
+        lthr=lthr,
         sex=sex,
         start_date=start,
         end_date=end,
@@ -145,20 +147,21 @@ def read_training_load_by_day(
     )
 
 
-@router.get("/trimp/by-day", response_model=list[dict])
-def read_trimp_by_day(
+@router.get("/hrtss/by-day", response_model=list[dict])
+def read_hrtss_by_day(
     start: date = DEFAULT_START,
     end: date = DEFAULT_END,
     max_hr: float = 192,
     resting_hr: float = 42,
+    lthr: float = 165,
     sex: Sex = "M",
     user_timezone: str | None = None,
     _user: User = Depends(require_viewer),
 ) -> list[dict]:
-    """Get TRIMP values by day.
+    """Get hrTSS values by day.
 
-    Returns a list of dicts with keys {"date", "trimp"} for each day.
+    Returns a list of dicts with keys {"date", "hrtss"} for each day.
     """
     runs = get_runs_for_date_range(start, end, user_timezone)
-    day_trimps = trimp_by_day(runs, start, end, max_hr, resting_hr, sex, user_timezone)
-    return [{"date": dt.date, "trimp": dt.trimp} for dt in day_trimps]
+    day_hrtss = hrtss_by_day(runs, start, end, max_hr, resting_hr, lthr, sex, user_timezone)
+    return [{"date": dt.date, "hrtss": dt.hrtss} for dt in day_hrtss]

--- a/fitness/app/routers/summary.py
+++ b/fitness/app/routers/summary.py
@@ -21,6 +21,7 @@ def get_trmnl_summary(
     user_timezone: str | None = None,
     max_hr: float = 192,
     resting_hr: float = 42,
+    lthr: float = 165,
     sex: Sex = "M",
     _user: User | None = Depends(require_viewer_or_api_key),
 ) -> TrmnlSummary:
@@ -62,6 +63,7 @@ def get_trmnl_summary(
         runs=runs,
         max_hr=max_hr,
         resting_hr=resting_hr,
+        lthr=lthr,
         sex=sex,
         start_date=today - timedelta(days=60),
         end_date=today,

--- a/fitness/models/training_load.py
+++ b/fitness/models/training_load.py
@@ -7,7 +7,7 @@ class TrainingLoad(BaseModel):
     atl: float
     ctl: float
     tsb: float
-    trimp: float
+    hrtss: float
 
 
 class DayTrainingLoad(BaseModel):

--- a/tests/agg/test_training_load.py
+++ b/tests/agg/test_training_load.py
@@ -2,7 +2,9 @@ import pytest
 from datetime import date
 from fitness.agg.training_load import (
     trimp,
-    trimp_by_day,
+    threshold_trimp,
+    hrtss,
+    hrtss_by_day,
     training_stress_balance,
     _exponential_training_load,
     _calculate_atl_and_ctl,
@@ -99,11 +101,86 @@ class TestTrimp:
         assert result_low == 0.0
 
 
-class TestTrimpByDay:
-    """Tests for the trimp_by_day() function."""
+class TestThresholdTrimp:
+    """Tests for the threshold_trimp() function."""
+
+    def test_threshold_trimp_male(self):
+        """Test threshold TRIMP calculation for male."""
+        result = threshold_trimp(max_hr=190, resting_hr=50, lthr=165, sex="M")
+        # 60 min * hr_relative * Y, where hr_relative = (165-50)/(190-50) ≈ 0.821
+        assert result > 0
+
+    def test_threshold_trimp_female(self):
+        """Test threshold TRIMP calculation for female."""
+        result = threshold_trimp(max_hr=190, resting_hr=50, lthr=165, sex="F")
+        assert result > 0
+
+    def test_threshold_trimp_lthr_equals_resting(self):
+        """When LTHR equals resting HR, threshold TRIMP should be 0."""
+        result = threshold_trimp(max_hr=190, resting_hr=50, lthr=50, sex="M")
+        assert result == 0.0
+
+
+class TestHrtss:
+    """Tests for the hrtss() function."""
+
+    def test_60min_at_lthr_equals_100(self):
+        """A 60-minute run at LTHR should produce hrTSS ≈ 100."""
+        run = RunFactory().make(
+            {
+                "date": date(2024, 1, 1),
+                "duration": 3600,  # 60 minutes
+                "avg_heart_rate": 165,  # At LTHR
+            }
+        )
+        result = hrtss(run, max_hr=190, resting_hr=50, lthr=165, sex="M")
+        assert result == pytest.approx(100.0, abs=0.01)
+
+    def test_hrtss_scales_with_trimp(self):
+        """hrTSS should be proportional to raw TRIMP."""
+        run = RunFactory().make(
+            {
+                "date": date(2024, 1, 1),
+                "duration": 2400,  # 40 minutes
+                "avg_heart_rate": 150,
+            }
+        )
+        raw = trimp(run, max_hr=190, resting_hr=50, sex="M")
+        thr = threshold_trimp(max_hr=190, resting_hr=50, lthr=165, sex="M")
+        expected = (raw / thr) * 100.0
+        result = hrtss(run, max_hr=190, resting_hr=50, lthr=165, sex="M")
+        assert result == pytest.approx(expected, abs=0.01)
+
+    def test_hrtss_no_heart_rate(self):
+        """hrTSS should raise ValueError when no heart rate."""
+        run = RunFactory().make(
+            {
+                "date": date(2024, 1, 1),
+                "duration": 2400,
+                "avg_heart_rate": None,
+            }
+        )
+        with pytest.raises(ValueError, match="Run must have an average heart rate"):
+            hrtss(run, max_hr=190, resting_hr=50, lthr=165, sex="M")
+
+    def test_hrtss_zero_threshold(self):
+        """When LTHR equals resting HR (threshold TRIMP is 0), hrTSS should be 0."""
+        run = RunFactory().make(
+            {
+                "date": date(2024, 1, 1),
+                "duration": 2400,
+                "avg_heart_rate": 150,
+            }
+        )
+        result = hrtss(run, max_hr=190, resting_hr=50, lthr=50, sex="M")
+        assert result == 0.0
+
+
+class TestHrtssByDay:
+    """Tests for the hrtss_by_day() function."""
 
     def test_single_run_day(self):
-        """Test TRIMP calculation for a single run on one day."""
+        """Test hrTSS calculation for a single run on one day."""
         runs = [
             RunFactory().make(
                 {
@@ -114,21 +191,22 @@ class TestTrimpByDay:
             )
         ]
 
-        result = trimp_by_day(
+        result = hrtss_by_day(
             runs=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 15),
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
         )
 
         assert len(result) == 1
         assert result[0].date == date(2024, 1, 15)
-        assert result[0].trimp == pytest.approx(72.1, abs=1.0)
+        assert result[0].hrtss > 0
 
     def test_multiple_runs_same_day(self):
-        """Test TRIMP calculation for multiple runs on the same day."""
+        """Test hrTSS calculation for multiple runs on the same day."""
         runs = [
             RunFactory().make(
                 {
@@ -148,22 +226,23 @@ class TestTrimpByDay:
             ),
         ]
 
-        result = trimp_by_day(
+        result = hrtss_by_day(
             runs=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 15),
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
         )
 
         assert len(result) == 1
         assert result[0].date == date(2024, 1, 15)
-        # Should be sum of both runs' TRIMP values
-        assert result[0].trimp > 0
+        # Should be sum of both runs' hrTSS values
+        assert result[0].hrtss > 0
 
     def test_multiple_days_with_gaps(self):
-        """Test TRIMP calculation across multiple days including days with no runs."""
+        """Test hrTSS calculation across multiple days including days with no runs."""
         runs = [
             RunFactory().make(
                 {
@@ -182,25 +261,26 @@ class TestTrimpByDay:
             ),
         ]
 
-        result = trimp_by_day(
+        result = hrtss_by_day(
             runs=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 17),
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
         )
 
         assert len(result) == 3  # 3 days total
         assert result[0].date == date(2024, 1, 15)
-        assert result[0].trimp > 0  # Has a run
+        assert result[0].hrtss > 0  # Has a run
         assert result[1].date == date(2024, 1, 16)
-        assert result[1].trimp == 0.0  # No runs
+        assert result[1].hrtss == 0.0  # No runs
         assert result[2].date == date(2024, 1, 17)
-        assert result[2].trimp > 0  # Has a run
+        assert result[2].hrtss > 0  # Has a run
 
     def test_runs_without_heart_rate_excluded(self):
-        """Test that runs without heart rate data are excluded from TRIMP calculation."""
+        """Test that runs without heart rate data are excluded from hrTSS calculation."""
         runs = [
             RunFactory().make(
                 {
@@ -219,37 +299,39 @@ class TestTrimpByDay:
             ),
         ]
 
-        result = trimp_by_day(
+        result = hrtss_by_day(
             runs=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 15),
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
         )
 
         assert len(result) == 1
         assert result[0].date == date(2024, 1, 15)
-        # Should only include TRIMP from the run with heart rate data
-        expected_trimp = trimp(runs[0], max_hr=190, resting_hr=50, sex="M")
-        assert result[0].trimp == pytest.approx(expected_trimp, abs=0.1)
+        # Should only include hrTSS from the run with heart rate data
+        expected = hrtss(runs[0], max_hr=190, resting_hr=50, lthr=165, sex="M")
+        assert result[0].hrtss == pytest.approx(expected, abs=0.1)
 
     def test_no_runs_in_range(self):
-        """Test TRIMP calculation when no runs exist in the date range."""
+        """Test hrTSS calculation when no runs exist in the date range."""
         runs = []
 
-        result = trimp_by_day(
+        result = hrtss_by_day(
             runs=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 17),
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
         )
 
         assert len(result) == 3  # 3 days in range
-        for day_trimp in result:
-            assert day_trimp.trimp == 0.0
+        for day_hrtss in result:
+            assert day_hrtss.hrtss == 0.0
 
     def test_runs_outside_date_range_excluded(self):
         """Test that runs outside the specified date range are excluded."""
@@ -279,23 +361,24 @@ class TestTrimpByDay:
             ),
         ]
 
-        result = trimp_by_day(
+        result = hrtss_by_day(
             runs=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 17),
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
         )
 
         assert len(result) == 3  # 3 days in range
         assert result[0].date == date(2024, 1, 15)
-        assert result[0].trimp > 0  # Only the run on Jan 15
-        assert result[1].trimp == 0.0  # No runs on Jan 16
-        assert result[2].trimp == 0.0  # No runs on Jan 17
+        assert result[0].hrtss > 0  # Only the run on Jan 15
+        assert result[1].hrtss == 0.0  # No runs on Jan 16
+        assert result[2].hrtss == 0.0  # No runs on Jan 17
 
     def test_start_date_before_any_runs(self):
-        """Test TRIMP calculation when start date is before any runs exist."""
+        """Test hrTSS calculation when start date is before any runs exist."""
         runs = [
             RunFactory().make(
                 {
@@ -306,21 +389,21 @@ class TestTrimpByDay:
             )
         ]
 
-        # Request TRIMP data starting from Jan 15 (before any runs)
-        result = trimp_by_day(
+        result = hrtss_by_day(
             runs=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 22),
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
         )
 
         assert len(result) == 8  # 8 days from Jan 15-22
         assert result[0].date == date(2024, 1, 15)
-        assert result[0].trimp == 0.0  # No runs on Jan 15
+        assert result[0].hrtss == 0.0  # No runs on Jan 15
         assert result[5].date == date(2024, 1, 20)
-        assert result[5].trimp > 0  # Has the run on Jan 20
+        assert result[5].hrtss > 0  # Has the run on Jan 20
 
 
 class TestExponentialTrainingLoad:
@@ -461,6 +544,7 @@ class TestTrainingStressBalance:
             runs=runs,
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
             start_date=date(2024, 1, 15),
             end_date=date(2024, 1, 17),
@@ -475,8 +559,8 @@ class TestTrainingStressBalance:
             assert day_load.training_load.atl >= 0
             # TSB = CTL - ATL, so it can be negative
             assert isinstance(day_load.training_load.tsb, float)
-            # Each day has a run, so TRIMP should be positive
-            assert day_load.training_load.trimp > 0
+            # Each day has a run, so hrTSS should be positive
+            assert day_load.training_load.hrtss > 0
 
     def test_training_stress_balance_no_heart_rate_runs_excluded(self):
         """Test that runs without heart rate are excluded from TSB calculation."""
@@ -501,6 +585,7 @@ class TestTrainingStressBalance:
             runs=runs,
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
             start_date=date(2024, 1, 15),
             end_date=date(2024, 1, 15),
@@ -517,6 +602,7 @@ class TestTrainingStressBalance:
             runs=[],
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
             start_date=date(2024, 1, 15),
             end_date=date(2024, 1, 17),
@@ -527,7 +613,7 @@ class TestTrainingStressBalance:
             assert day_load.training_load.ctl == 0.0
             assert day_load.training_load.atl == 0.0
             assert day_load.training_load.tsb == 0.0
-            assert day_load.training_load.trimp == 0.0
+            assert day_load.training_load.hrtss == 0.0
 
     def test_training_stress_balance_different_sex(self):
         """Test that male and female calculations produce different results."""
@@ -545,6 +631,7 @@ class TestTrainingStressBalance:
             runs=runs,
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
             start_date=date(2024, 1, 15),
             end_date=date(2024, 1, 15),
@@ -554,12 +641,13 @@ class TestTrainingStressBalance:
             runs=runs,
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="F",
             start_date=date(2024, 1, 15),
             end_date=date(2024, 1, 15),
         )
 
-        # Results should be different due to different TRIMP calculations
+        # Results should be different due to different hrTSS calculations
         assert result_male[0].training_load.atl != result_female[0].training_load.atl
         assert result_male[0].training_load.ctl != result_female[0].training_load.ctl
 
@@ -588,6 +676,7 @@ class TestTrainingStressBalance:
             runs=runs,
             max_hr=190,
             resting_hr=50,
+            lthr=165,
             sex="M",
             start_date=date(2024, 1, 15),  # Only want results from this date
             end_date=date(2024, 1, 15),

--- a/tests/app/test_date_range_queries.py
+++ b/tests/app/test_date_range_queries.py
@@ -128,6 +128,7 @@ def test_training_load_uses_all_runs(monkeypatch, viewer_client: TestClient):
             "end": "2025-06-30",
             "max_hr": "192",
             "resting_hr": "42",
+            "lthr": "165",
             "sex": "M",
         },
     )

--- a/tests/e2e/test_metrics_endpoints.py
+++ b/tests/e2e/test_metrics_endpoints.py
@@ -192,7 +192,7 @@ def test_shoe_mileage_metrics(viewer_client):
 
 @pytest.mark.e2e
 def test_training_load_metrics(viewer_client):
-    """Test training load and TRIMP metrics."""
+    """Test training load and hrTSS metrics."""
     # Create runs with heart rate data
     runs = [
         Run(
@@ -227,9 +227,9 @@ def test_training_load_metrics(viewer_client):
     inserted = bulk_create_runs(runs)
     assert inserted == 3
 
-    # Test TRIMP by day
+    # Test hrTSS by day
     res = viewer_client.get(
-        "/metrics/trimp/by-day",
+        "/metrics/hrtss/by-day",
         params={
             "start": "2024-10-01",
             "end": "2024-10-03",
@@ -239,24 +239,24 @@ def test_training_load_metrics(viewer_client):
         },
     )
     assert res.status_code == 200
-    trimp_data = res.json()
+    hrtss_data = res.json()
 
-    # Should have TRIMP values for days with runs
-    assert isinstance(trimp_data, list)
-    assert len(trimp_data) > 0
+    # Should have hrTSS values for days with runs
+    assert isinstance(hrtss_data, list)
+    assert len(hrtss_data) > 0
 
-    # Check structure of TRIMP data
-    trimp_entry = trimp_data[0]
-    assert "date" in trimp_entry
-    assert "trimp" in trimp_entry
-    assert isinstance(trimp_entry["trimp"], (int, float))
+    # Check structure of hrTSS data
+    hrtss_entry = hrtss_data[0]
+    assert "date" in hrtss_entry
+    assert "hrtss" in hrtss_entry
+    assert isinstance(hrtss_entry["hrtss"], (int, float))
 
     # Find specific days
-    oct_1_trimp = next(
-        (entry for entry in trimp_data if entry["date"] == "2024-10-01"), None
+    oct_1_hrtss = next(
+        (entry for entry in hrtss_data if entry["date"] == "2024-10-01"), None
     )
-    if oct_1_trimp:
-        assert oct_1_trimp["trimp"] > 0  # Should have positive TRIMP for day with run
+    if oct_1_hrtss:
+        assert oct_1_hrtss["hrtss"] > 0  # Should have positive hrTSS for day with run
 
     # Test training load by day (requires more parameters)
     res = viewer_client.get(
@@ -326,9 +326,9 @@ def test_metrics_with_timezone(viewer_client):
     tz_mileage = res.json()
     assert tz_mileage >= 0.0  # Should handle timezone conversion
 
-    # Test TRIMP with timezone
+    # Test hrTSS with timezone
     res = viewer_client.get(
-        "/metrics/trimp/by-day",
+        "/metrics/hrtss/by-day",
         params={
             "start": "2024-11-01",
             "end": "2024-11-01",
@@ -339,8 +339,8 @@ def test_metrics_with_timezone(viewer_client):
         },
     )
     assert res.status_code == 200
-    tz_trimp = res.json()
-    assert isinstance(tz_trimp, list)
+    tz_hrtss = res.json()
+    assert isinstance(tz_hrtss, list)
 
 
 @pytest.mark.e2e
@@ -358,7 +358,7 @@ def test_metrics_error_cases(viewer_client):
 
     # Test with invalid heart rate values
     res = viewer_client.get(
-        "/metrics/trimp/by-day",
+        "/metrics/hrtss/by-day",
         params={
             "start": "2024-01-01",
             "end": "2024-01-02",
@@ -370,7 +370,7 @@ def test_metrics_error_cases(viewer_client):
 
     # Test with invalid sex value
     res = viewer_client.get(
-        "/metrics/trimp/by-day",
+        "/metrics/hrtss/by-day",
         params={
             "start": "2024-01-01",
             "end": "2024-01-02",
@@ -402,9 +402,9 @@ def test_metrics_empty_data(viewer_client):
     assert isinstance(empty_daily, list)
     # Should return empty list or list with zero mileage
 
-    # Test TRIMP for empty range
+    # Test hrTSS for empty range
     res = viewer_client.get(
-        "/metrics/trimp/by-day",
+        "/metrics/hrtss/by-day",
         params={
             "start": "1990-01-01",
             "end": "1990-01-01",
@@ -414,5 +414,5 @@ def test_metrics_empty_data(viewer_client):
         },
     )
     assert res.status_code == 200
-    empty_trimp = res.json()
-    assert isinstance(empty_trimp, list)
+    empty_hrtss = res.json()
+    assert isinstance(empty_hrtss, list)

--- a/tests/e2e/test_metrics_endpoints.py
+++ b/tests/e2e/test_metrics_endpoints.py
@@ -266,6 +266,7 @@ def test_training_load_metrics(viewer_client):
             "end": "2024-10-03",
             "max_hr": 190.0,
             "resting_hr": 50.0,
+            "lthr": 165.0,
             "sex": "M",
         },
     )


### PR DESCRIPTION
## Summary

- Adds `threshold_trimp()` and `hrtss()` functions that normalize raw TRIMP so 1hr at LTHR = 100
- Adds `lthr` (lactate threshold HR, default 165) as a new query parameter on training load and hrTSS endpoints
- Renames `/metrics/trimp/by-day` to `/metrics/hrtss/by-day`
- ATL, CTL, and TSB are now computed from daily hrTSS instead of raw TRIMP
- The existing `trimp()` function is unchanged — hrTSS wraps it

## Test plan

- [x] `make test` passes (354 tests, including new TestThresholdTrimp and TestHrtss classes)
- [ ] Verify 60-min run at avg HR = LTHR produces hrTSS ≈ 100
- [ ] Deploy alongside fitness-dashboard#157 (coordinated breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)