### PR TITLE
Fix /run-activity-feed to filter by user's local date

### DIFF
--- a/fitness/app/app.py
+++ b/fitness/app/app.py
@@ -6,7 +6,8 @@ import os
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import date, datetime
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
 from pathlib import Path
 from typing import Literal, TypeVar
 
@@ -234,18 +235,33 @@ def read_activity_feed(
     start: date = DEFAULT_START,
     end: date = DEFAULT_END,
     sort_order: Literal["asc", "desc"] = "desc",
+    user_timezone: str | None = None,
     _user: User = Depends(require_viewer),
 ) -> list[ActivityFeedRunItem | ActivityFeedWorkoutItem]:
     """Get a unified activity feed of solo runs and run workouts.
 
     Runs that belong to a workout appear nested inside their workout entry
     rather than as separate items. Sorted by date.
+
+    When `user_timezone` is provided, `start`/`end` are interpreted as dates
+    in that timezone and the feed is filtered by each run's local date.
     """
     from fitness.db.runs import get_run_details_in_date_range, get_all_run_details
     from fitness.app.routers.run_workouts import build_activity_feed
 
     if start != DEFAULT_START or end != DEFAULT_END:
-        all_runs = get_run_details_in_date_range(start, end)
+        all_runs = get_run_details_in_date_range(
+            start, end, user_timezone=user_timezone
+        )
+        if user_timezone is not None:
+            tz = ZoneInfo(user_timezone)
+            all_runs = [
+                r
+                for r in all_runs
+                if start
+                <= r.datetime_utc.replace(tzinfo=timezone.utc).astimezone(tz).date()
+                <= end
+            ]
     else:
         all_runs = get_all_run_details()
 

--- a/fitness/db/runs.py
+++ b/fitness/db/runs.py
@@ -231,11 +231,19 @@ def get_run_details_in_date_range(
     end_date: date,
     include_deleted: bool = False,
     synced: bool | None = None,
+    user_timezone: str | None = None,
 ) -> list[RunDetail]:
     """Get detailed runs with shoes and sync info within a date range.
 
     Joins `runs` to `shoes` and `synced_runs`.
+
+    When `user_timezone` is set, the SQL range is widened by ±1 day to cover
+    runs whose UTC date differs from their local date. Callers must do exact
+    local-date filtering in Python after this returns.
     """
+    if user_timezone is not None:
+        start_date = start_date - timedelta(days=1)
+        end_date = end_date + timedelta(days=1)
     with get_db_cursor() as cursor:
         conditions: list[sql.Composable] = [
             sql.SQL("DATE(r.datetime_utc) BETWEEN %s AND %s")

--- a/tests/app/run_workouts_router/test_run_workouts.py
+++ b/tests/app/run_workouts_router/test_run_workouts.py
@@ -508,3 +508,51 @@ class TestActivityFeed:
         assert workout["run_count"] == 2
         # Elapsed: from 8:00:00 to 8:15:00 + 900s = 8:30:00 = 1800s
         assert workout["elapsed_seconds"] == 1800.0
+
+    @patch("fitness.db.runs.get_run_details_in_date_range")
+    def test_filters_by_local_date_across_utc_midnight_boundary(
+        self,
+        mock_get_details: MagicMock,
+        viewer_client: TestClient,
+    ):
+        """Two runs sharing a UTC date but straddling midnight in the user's tz
+        must be placed on separate local dates.
+
+        Chicago is UTC-5 in April (CDT), so 05:00 UTC = 00:00 Chicago. These
+        two runs are only an hour apart but fall on different Chicago dates:
+
+        - 2026-04-10 04:30 UTC → 2026-04-09 23:30 America/Chicago (April 9)
+        - 2026-04-10 05:30 UTC → 2026-04-10 00:30 America/Chicago (April 10)
+
+        Both have UTC date = April 10, so filtering by UTC date alone would
+        either include both or neither. With user_timezone=America/Chicago
+        and a query window of April 9, only the first should appear.
+        """
+        run_chicago_april_9 = _make_run_detail(
+            "run_just_before_midnight_chicago",
+            datetime(2026, 4, 10, 4, 30, 0),
+        )
+        run_chicago_april_10 = _make_run_detail(
+            "run_just_after_midnight_chicago",
+            datetime(2026, 4, 10, 5, 30, 0),
+        )
+        mock_get_details.return_value = [
+            run_chicago_april_9,
+            run_chicago_april_10,
+        ]
+
+        response = viewer_client.get(
+            "/run-activity-feed",
+            params={
+                "start": "2026-04-09",
+                "end": "2026-04-09",
+                "user_timezone": "America/Chicago",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        ids = {item["item"]["id"] for item in data if item["type"] == "run"}
+        assert ids == {"run_just_before_midnight_chicago"}, (
+            f"Expected only the pre-midnight Chicago run, got {ids}"
+        )


### PR DESCRIPTION
## Summary

The `/run-activity-feed` endpoint (used by the dashboard's All Runs page) filtered runs by **UTC date**, so a run that happened late at night in the user's timezone and crossed into the next UTC day landed on the wrong day — e.g. a run at 22:30 America/Chicago is 03:30 UTC the next day, and would silently disappear from a "through today" window.

This mirrors the pattern already used by `/runs` at `fitness/app/app.py:159`:

- `get_run_details_in_date_range` accepts an optional `user_timezone`; when set, it widens the SQL query by ±1 day so we don't miss rows near the boundary.
- `/run-activity-feed` accepts `user_timezone`, forwards it to the DB helper, and then post-filters the returned runs by each run's local date using `ZoneInfo`.
- Without `user_timezone` the old UTC-date behavior is preserved.

## Bug demonstration (TDD)

Added a regression test at `tests/app/run_workouts_router/test_run_workouts.py` using two runs that **share a UTC date** but straddle midnight in America/Chicago:

- `2026-04-10 04:30 UTC` → `2026-04-09 23:30 Chicago` (April 9 local)
- `2026-04-10 05:30 UTC` → `2026-04-10 00:30 Chicago` (April 10 local)

Querying `start=2026-04-09&end=2026-04-09&user_timezone=America/Chicago` must return only the first. Verified red with the fix removed, then green with the fix in place.

## Scope

Only `/run-activity-feed`. `/runs/details` and `/runs-details` have the same bug and different dashboard callers (editorial dashboard, bulk sync dialog) — left as a follow-up.

The corresponding dashboard change that actually sends `user_timezone` is in eswan18/fitness-dashboard.

## Test plan

- [x] `make test` — all 355 unit tests pass
- [x] New test fails red with the endpoint unchanged, passes green after the fix
- [ ] After deploy: load the All Runs page on staging, confirm `/run-activity-feed` request carries `user_timezone=America/Chicago`, and that a late-evening run is on the right day

🤖 Generated with [Claude Code](https://claude.com/claude-code)