### PR TITLE
Add GET /shoes/recent endpoint

### DIFF
--- a/fitness/app/routers/shoes.py
+++ b/fitness/app/routers/shoes.py
@@ -4,13 +4,14 @@ from fastapi import APIRouter, HTTPException, Depends
 
 from fitness.db.shoes import (
     get_shoes,
+    get_shoes_with_last_used,
     get_shoe_by_id,
     retire_shoe_by_id,
     unretire_shoe_by_id,
     merge_shoes,
     delete_shoe_by_id,
 )
-from fitness.models.shoe import Shoe
+from fitness.models.shoe import Shoe, ShoeRecentUse
 from fitness.models.user import User
 from fitness.app.models import UpdateShoeRequest, MergeShoesRequest
 from fitness.app.auth import require_viewer, require_editor
@@ -30,6 +31,20 @@ def read_shoes(
                 If None, return all shoes.
     """
     return get_shoes(retired=retired)
+
+
+@router.get("/recent", response_model=list[ShoeRecentUse])
+def read_recent_shoes(
+    include_retired: bool = False,
+    _user: User = Depends(require_viewer),
+) -> list[ShoeRecentUse]:
+    """Get shoes ordered by most-recently-used.
+
+    Returns all non-deleted shoes paired with the datetime of their most
+    recent run, sorted by last_used_date DESC NULLS LAST. Retired shoes are
+    excluded unless ``include_retired=true``.
+    """
+    return get_shoes_with_last_used(include_retired=include_retired)
 
 
 @router.patch("/{shoe_id}", response_model=dict[str, str])

--- a/fitness/db/shoes.py
+++ b/fitness/db/shoes.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from psycopg import sql
 
-from fitness.models.shoe import Shoe
+from fitness.models.shoe import Shoe, ShoeRecentUse
 from .connection import get_db_cursor, get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -126,6 +126,44 @@ def delete_shoe_by_id(shoe_id: str) -> bool:
             (shoe_id,),
         )
         return cursor.rowcount > 0
+
+
+def get_shoes_with_last_used(include_retired: bool = False) -> List[ShoeRecentUse]:
+    """Return shoes paired with the datetime of their most recent non-deleted run.
+
+    Results are ordered by last_used_date DESC NULLS LAST. Soft-deleted shoes
+    are always excluded. Retired shoes are excluded unless include_retired is True.
+    Soft-deleted runs are ignored when determining the last-used datetime.
+    """
+    conditions: list[sql.Composable] = [sql.SQL("s.deleted_at IS NULL")]
+    if not include_retired:
+        conditions.append(sql.SQL("s.retired_at IS NULL"))
+    where_clause = sql.SQL("WHERE ") + sql.SQL(" AND ").join(conditions)
+
+    query = sql.SQL("""
+        SELECT id, name, retired_at, notes, retirement_notes, deleted_at, last_used_date
+        FROM (
+            SELECT DISTINCT ON (s.id)
+                s.id, s.name, s.retired_at, s.notes, s.retirement_notes, s.deleted_at,
+                r.datetime_utc AS last_used_date
+            FROM shoes s
+            LEFT JOIN runs r ON r.shoe_id = s.id AND r.deleted_at IS NULL
+            {where_clause}
+            ORDER BY s.id, r.datetime_utc DESC NULLS LAST
+        ) sub
+        ORDER BY last_used_date DESC NULLS LAST, name
+    """).format(where_clause=where_clause)
+
+    with get_db_cursor() as cursor:
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        return [
+            ShoeRecentUse(
+                shoe=_row_to_shoe(row[:6]),
+                last_used_date=row[6],
+            )
+            for row in rows
+        ]
 
 
 def _row_to_shoe(row) -> Shoe:

--- a/fitness/models/shoe.py
+++ b/fitness/models/shoe.py
@@ -97,3 +97,10 @@ class ShoeMileage(BaseModel):
 
     def __lt__(self, other: "ShoeMileage") -> bool:
         return self.mileage < other.mileage
+
+
+class ShoeRecentUse(BaseModel):
+    """Shoe with the datetime of its most recent run, if any."""
+
+    shoe: Shoe
+    last_used_date: Optional[datetime] = None

--- a/tests/app/shoe_router/test_recent_endpoint.py
+++ b/tests/app/shoe_router/test_recent_endpoint.py
@@ -1,0 +1,79 @@
+"""Test GET /shoes/recent endpoint."""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from fitness.models.shoe import Shoe, ShoeRecentUse
+
+
+def test_recent_shoes_endpoint_requires_auth(client: TestClient):
+    """Unauthenticated requests are rejected with a Bearer challenge."""
+    response = client.get("/shoes/recent")
+    assert response.status_code == 401
+    assert "WWW-Authenticate" in response.headers
+    assert "Bearer" in response.headers["WWW-Authenticate"]
+
+
+def test_recent_shoes_endpoint_returns_sorted_list(
+    monkeypatch, viewer_client: TestClient
+):
+    """Viewer can fetch shoes ordered by last_used_date DESC NULLS LAST."""
+    newer = datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc)
+    older = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+
+    recent = [
+        ShoeRecentUse(
+            shoe=Shoe(id="pegasus", name="Pegasus"),
+            last_used_date=newer,
+        ),
+        ShoeRecentUse(
+            shoe=Shoe(id="ghost", name="Ghost"),
+            last_used_date=older,
+        ),
+        ShoeRecentUse(
+            shoe=Shoe(id="unused", name="Unused"),
+            last_used_date=None,
+        ),
+    ]
+
+    captured: dict = {}
+
+    def mock_get_shoes_with_last_used(include_retired: bool = False):
+        captured["include_retired"] = include_retired
+        return recent
+
+    monkeypatch.setattr(
+        "fitness.app.routers.shoes.get_shoes_with_last_used",
+        mock_get_shoes_with_last_used,
+    )
+
+    response = viewer_client.get("/shoes/recent")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["shoe"]["id"] for item in body] == ["pegasus", "ghost", "unused"]
+    assert body[0]["last_used_date"].startswith("2026-04-10")
+    assert body[2]["last_used_date"] is None
+    assert captured["include_retired"] is False
+
+
+def test_recent_shoes_endpoint_include_retired_param(
+    monkeypatch, viewer_client: TestClient
+):
+    """The include_retired query param is forwarded to the DB function."""
+    captured: dict = {}
+
+    def mock_get_shoes_with_last_used(include_retired: bool = False):
+        captured["include_retired"] = include_retired
+        return []
+
+    monkeypatch.setattr(
+        "fitness.app.routers.shoes.get_shoes_with_last_used",
+        mock_get_shoes_with_last_used,
+    )
+
+    response = viewer_client.get("/shoes/recent?include_retired=true")
+
+    assert response.status_code == 200
+    assert captured["include_retired"] is True


### PR DESCRIPTION
## Summary
- New `GET /shoes/recent` endpoint returning shoes ordered by `last_used_date DESC NULLS LAST`, backing the dashboard's "Recent Shoes" widget (currently rendering hardcoded data).
- Response model `ShoeRecentUse` wraps `Shoe` with a nullable `last_used_date`. Soft-deleted shoes and soft-deleted runs are always excluded; retired shoes are excluded unless `include_retired=true`.
- Uses `require_viewer` auth, matching `GET /shoes/`.

## Test plan
- [x] New unit tests cover auth (401 + Bearer challenge), ordering, and the `include_retired` passthrough
- [x] Full shoe router suite passes (15 tests)
- [x] `make lint` and `make ty` clean
- [ ] Frontend will be wired up in a follow-up PR