### PR TITLE
Add cycling activities from Strava to fatigue

### DIFF
--- a/alembic/versions/b3a7e9f2c1d4_create_rides_table.py
+++ b/alembic/versions/b3a7e9f2c1d4_create_rides_table.py
@@ -1,0 +1,44 @@
+"""Create rides table
+
+Revision ID: b3a7e9f2c1d4
+Revises: 6dda1ac0535c
+Create Date: 2026-05-09 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b3a7e9f2c1d4"
+down_revision: Union[str, Sequence[str], None] = "6dda1ac0535c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE rides (
+            id VARCHAR(255) PRIMARY KEY,
+            datetime_utc TIMESTAMP NOT NULL,
+            type VARCHAR(50) NOT NULL CHECK (type IN ('Outdoor Ride', 'Indoor Ride')),
+            distance FLOAT NOT NULL,
+            duration FLOAT NOT NULL,
+            source VARCHAR(50) NOT NULL CHECK (source IN ('Strava')),
+            avg_heart_rate FLOAT,
+            deleted_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    op.execute("CREATE INDEX idx_rides_datetime_utc ON rides (datetime_utc)")
+    op.execute("CREATE INDEX idx_rides_source ON rides (source)")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DROP TABLE IF EXISTS rides")

--- a/alembic/versions/c2f8d4a91e07_create_synced_rides_table.py
+++ b/alembic/versions/c2f8d4a91e07_create_synced_rides_table.py
@@ -1,0 +1,45 @@
+"""Create synced_rides table
+
+Revision ID: c2f8d4a91e07
+Revises: b3a7e9f2c1d4
+Create Date: 2026-05-10 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c2f8d4a91e07"
+down_revision: Union[str, Sequence[str], None] = "b3a7e9f2c1d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE synced_rides (
+            id SERIAL PRIMARY KEY,
+            ride_id VARCHAR(255) NOT NULL,
+            ride_version INTEGER NOT NULL DEFAULT 1,
+            google_event_id VARCHAR(255) NOT NULL,
+            synced_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            sync_status VARCHAR(20) NOT NULL DEFAULT 'synced' CHECK (sync_status IN ('synced', 'failed', 'pending')),
+            error_message TEXT,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            CONSTRAINT fk_synced_rides_ride_id FOREIGN KEY (ride_id) REFERENCES rides(id),
+            CONSTRAINT uq_synced_rides_ride_id UNIQUE (ride_id)
+        );
+
+        CREATE INDEX idx_synced_rides_ride_id ON synced_rides(ride_id);
+        CREATE INDEX idx_synced_rides_sync_status ON synced_rides(sync_status);
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DROP TABLE IF EXISTS synced_rides CASCADE;")

--- a/fitness/agg/training_load.py
+++ b/fitness/agg/training_load.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 import math
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import NamedTuple
 
 from fitness.models import Run, Ride, DayTrainingLoad, TrainingLoad, Sex
@@ -99,7 +100,7 @@ def _calculate_atl_and_ctl(
 
 
 def training_stress_balance(
-    activities: list[Run | Ride],
+    activities: Sequence[Run | Ride],
     max_hr: float,
     resting_hr: float,
     lthr: float,
@@ -171,7 +172,7 @@ def training_stress_balance(
 
 
 def hrtss_by_day(
-    activities: list[Run | Ride],
+    activities: Sequence[Run | Ride],
     start: date,
     end: date,
     max_hr: float,

--- a/fitness/agg/training_load.py
+++ b/fitness/agg/training_load.py
@@ -3,8 +3,8 @@ import math
 from collections import defaultdict
 from typing import NamedTuple
 
-from fitness.models import Run, DayTrainingLoad, TrainingLoad, Sex
-from fitness.utils.timezone import convert_runs_to_user_timezone
+from fitness.models import Run, Ride, DayTrainingLoad, TrainingLoad, Sex
+from fitness.utils.timezone import convert_activities_to_user_timezone
 
 
 class DayHrtss(NamedTuple):
@@ -16,9 +16,9 @@ ATL_LOOKBACK = 7
 CTL_LOOKBACK = 42
 
 
-def trimp(run: Run, max_hr: float, resting_hr: float, sex: Sex) -> float:
+def trimp(activity: Run | Ride, max_hr: float, resting_hr: float, sex: Sex) -> float:
     """
-    Calculate the Banister TRaining IMPulse score for a run.
+    Calculate the Banister TRaining IMPulse score for a HR-bearing activity.
 
     TRIMP = Duration (minutes) x HR_Relative x Y
     where HR_Relative is the relative heart rate:
@@ -27,9 +27,11 @@ def trimp(run: Run, max_hr: float, resting_hr: float, sex: Sex) -> float:
         - For men: Y = 0.64 * e^(1.92 x HR_Relative)
         - For women: Y = 0.86 * e^(1.67 x HR_Relative)
     """
-    if run.avg_heart_rate is None:
-        raise ValueError("Run must have an average heart rate to calculate TRIMP.")
-    hr_relative = (run.avg_heart_rate - resting_hr) / (max_hr - resting_hr)
+    if activity.avg_heart_rate is None:
+        raise ValueError(
+            "Activity must have an average heart rate to calculate TRIMP."
+        )
+    hr_relative = (activity.avg_heart_rate - resting_hr) / (max_hr - resting_hr)
     # Clamp hr_relative to the range [0, 1]
     hr_relative = max(0.0, min(1.0, hr_relative))
     match sex:
@@ -37,7 +39,7 @@ def trimp(run: Run, max_hr: float, resting_hr: float, sex: Sex) -> float:
             y = 0.64 * math.exp(1.92 * hr_relative)
         case "F":
             y = 0.86 * math.exp(1.67 * hr_relative)
-    duration_minutes = run.duration / 60
+    duration_minutes = activity.duration / 60
     return duration_minutes * hr_relative * y
 
 
@@ -56,14 +58,16 @@ def threshold_trimp(max_hr: float, resting_hr: float, lthr: float, sex: Sex) -> 
     return 60.0 * hr_relative * y
 
 
-def hrtss(run: Run, max_hr: float, resting_hr: float, lthr: float, sex: Sex) -> float:
-    """Calculate Heart Rate Training Stress Score for a run.
+def hrtss(
+    activity: Run | Ride, max_hr: float, resting_hr: float, lthr: float, sex: Sex
+) -> float:
+    """Calculate Heart Rate Training Stress Score for an activity.
 
     hrTSS = (activity_TRIMP / threshold_TRIMP) * 100
 
-    A 60-minute run at LTHR produces hrTSS ≈ 100.
+    A 60-minute activity at LTHR produces hrTSS ≈ 100.
     """
-    activity_trimp = trimp(run, max_hr, resting_hr, sex)
+    activity_trimp = trimp(activity, max_hr, resting_hr, sex)
     thr_trimp = threshold_trimp(max_hr, resting_hr, lthr, sex)
     if thr_trimp == 0:
         return 0.0
@@ -95,7 +99,7 @@ def _calculate_atl_and_ctl(
 
 
 def training_stress_balance(
-    runs: list[Run],
+    activities: list[Run | Ride],
     max_hr: float,
     resting_hr: float,
     lthr: float,
@@ -111,7 +115,8 @@ def training_stress_balance(
     that 1 hour at LTHR = 100).
 
     Args:
-        runs: List of runs (with UTC dates)
+        activities: List of HR-bearing activities (runs and/or rides) with UTC dates.
+            Activities without an `avg_heart_rate` are skipped.
         max_hr: Maximum heart rate
         resting_hr: Resting heart rate
         lthr: Lactate threshold heart rate
@@ -120,17 +125,14 @@ def training_stress_balance(
         end_date: End date in user's timezone
         user_timezone: User's timezone (e.g., "America/Chicago"). If None, uses UTC dates.
     """
-    # Filter runs to only those with a valid average heart rate.
-    hr_runs = [run for run in runs if run.avg_heart_rate is not None]
-
-    # Convert runs to user timezone if specified
-    user_tz_runs = convert_runs_to_user_timezone(hr_runs, user_timezone)
+    hr_activities = [a for a in activities if a.avg_heart_rate is not None]
+    user_tz_activities = convert_activities_to_user_timezone(
+        hr_activities, user_timezone
+    )
 
     hrtss_by_date: list[tuple[date, float]] = []
 
-    # Handle empty runs case
-    if not user_tz_runs:
-        # Return zero values for each day in the requested range
+    if not user_tz_activities:
         current_date = start_date
         while current_date <= end_date:
             hrtss_by_date.append((current_date, 0.0))
@@ -145,17 +147,17 @@ def training_stress_balance(
             for (d, c, a, t, h) in zip(dates, ctl, atl, tsb, hrtss_values)
         ]
 
-    # Always start calculations from the beginning of running data, because these metrics converge over time.
+    # Always start calculations from the earliest activity, because these metrics converge over time.
     # If we start at the start date, metrics will be inaccurately close to zero.
-    first_run_date = min(localized_run.local_date for localized_run in user_tz_runs)
-    for i in range((end_date - first_run_date).days + 1):
-        current_date = first_run_date + timedelta(days=i)
-        runs_for_day = [
-            localized_run
-            for localized_run in user_tz_runs
-            if localized_run.local_date == current_date
+    first_activity_date = min(a.local_date for a in user_tz_activities)
+    for i in range((end_date - first_activity_date).days + 1):
+        current_date = first_activity_date + timedelta(days=i)
+        activities_for_day = [
+            a for a in user_tz_activities if a.local_date == current_date
         ]
-        day_hrtss_values = [hrtss(run, max_hr, resting_hr, lthr, sex) for run in runs_for_day]
+        day_hrtss_values = [
+            hrtss(a, max_hr, resting_hr, lthr, sex) for a in activities_for_day
+        ]
         hrtss_by_date.append((current_date, sum(day_hrtss_values, start=0.0)))
     atl, ctl = _calculate_atl_and_ctl([h for _, h in hrtss_by_date])
     tsb = [ctl_value - atl_value for ctl_value, atl_value in zip(ctl, atl)]
@@ -169,7 +171,7 @@ def training_stress_balance(
 
 
 def hrtss_by_day(
-    runs: list[Run],
+    activities: list[Run | Ride],
     start: date,
     end: date,
     max_hr: float,
@@ -182,7 +184,8 @@ def hrtss_by_day(
     Calculate hrTSS values for each day in the date range.
 
     Args:
-        runs: List of runs (with UTC dates)
+        activities: List of activities (runs and/or rides) with UTC dates.
+            Activities without `avg_heart_rate` are skipped.
         start: Start date in user's timezone
         end: End date in user's timezone
         max_hr: Maximum heart rate
@@ -191,28 +194,23 @@ def hrtss_by_day(
         sex: Sex ("M" or "F")
         user_timezone: User's timezone (e.g., "America/Chicago"). If None, uses UTC dates.
     """
-    # Filter runs to only those with heart rate data
-    runs_with_hr = [r for r in runs if r.avg_heart_rate is not None]
+    activities_with_hr = [a for a in activities if a.avg_heart_rate is not None]
+    user_tz_activities = convert_activities_to_user_timezone(
+        activities_with_hr, user_timezone
+    )
 
-    # Convert runs to user timezone if specified
-    user_tz_runs = convert_runs_to_user_timezone(runs_with_hr, user_timezone)
+    activities_by_date = defaultdict(list)
+    for a in user_tz_activities:
+        if start <= a.local_date <= end:
+            activities_by_date[a.local_date].append(a)
 
-    # Group runs by local date
-    runs_by_date = defaultdict(list)
-    for localized_run in user_tz_runs:
-        if start <= localized_run.local_date <= end:
-            runs_by_date[localized_run.local_date].append(localized_run)
-
-    # Calculate hrTSS for each day
     day_hrtss_list = []
     current_date = start
     while current_date <= end:
-        day_runs = runs_by_date[current_date]
+        day_activities = activities_by_date[current_date]
         daily_hrtss = 0.0
-
-        for run in day_runs:
-            daily_hrtss += hrtss(run, max_hr, resting_hr, lthr, sex)
-
+        for a in day_activities:
+            daily_hrtss += hrtss(a, max_hr, resting_hr, lthr, sex)
         day_hrtss_list.append(DayHrtss(date=current_date, hrtss=daily_hrtss))
         current_date += timedelta(days=1)
 

--- a/fitness/app/app.py
+++ b/fitness/app/app.py
@@ -19,6 +19,7 @@ from fitness.models import Run
 from fitness.models.run import LocalizedRun
 from fitness.models.run_detail import RunDetail
 from fitness.app.routers.run_workouts import (
+    ActivityFeedRideItem,
     ActivityFeedRunItem,
     ActivityFeedWorkoutItem,
 )
@@ -237,22 +238,24 @@ def read_activity_feed(
     sort_order: Literal["asc", "desc"] = "desc",
     user_timezone: str | None = None,
     _user: User = Depends(require_viewer),
-) -> list[ActivityFeedRunItem | ActivityFeedWorkoutItem]:
-    """Get a unified activity feed of solo runs and run workouts.
+) -> list[ActivityFeedRunItem | ActivityFeedWorkoutItem | ActivityFeedRideItem]:
+    """Get a unified cardio activity feed of solo runs, run workouts, and rides.
 
     Runs that belong to a workout appear nested inside their workout entry
-    rather than as separate items. Sorted by date.
+    rather than as separate items. Rides are always solo items. Sorted by date.
 
     When `user_timezone` is provided, `start`/`end` are interpreted as dates
-    in that timezone and the feed is filtered by each run's local date.
+    in that timezone and the feed is filtered by each activity's local date.
     """
     from fitness.db.runs import get_run_details_in_date_range, get_all_run_details
+    from fitness.db.rides import get_rides_for_date_range, get_all_rides
     from fitness.app.routers.run_workouts import build_activity_feed
 
     if start != DEFAULT_START or end != DEFAULT_END:
         all_runs = get_run_details_in_date_range(
             start, end, user_timezone=user_timezone
         )
+        rides = get_rides_for_date_range(start, end, user_timezone=user_timezone)
         if user_timezone is not None:
             tz = ZoneInfo(user_timezone)
             all_runs = [
@@ -262,10 +265,18 @@ def read_activity_feed(
                 <= r.datetime_utc.replace(tzinfo=timezone.utc).astimezone(tz).date()
                 <= end
             ]
+            rides = [
+                r
+                for r in rides
+                if start
+                <= r.datetime_utc.replace(tzinfo=timezone.utc).astimezone(tz).date()
+                <= end
+            ]
     else:
         all_runs = get_all_run_details()
+        rides = get_all_rides()
 
-    return build_activity_feed(all_runs, sort_order=sort_order)
+    return build_activity_feed(all_runs, rides=rides, sort_order=sort_order)
 
 
 def sort_runs_generic(

--- a/fitness/app/app.py
+++ b/fitness/app/app.py
@@ -27,6 +27,7 @@ from .constants import DEFAULT_START, DEFAULT_END
 from .routers import (
     metrics_router,
     shoe_router,
+    ride_router,
     run_router,
     sync_router,
     oauth_router,
@@ -120,6 +121,7 @@ app = FastAPI(lifespan=lifespan)
 app.include_router(metrics_router)
 app.include_router(shoe_router)
 app.include_router(run_router)
+app.include_router(ride_router)
 app.include_router(sync_router)
 app.include_router(oauth_router)
 app.include_router(strava_router)

--- a/fitness/app/app.py
+++ b/fitness/app/app.py
@@ -231,7 +231,7 @@ def read_run_details_alt(
     )
 
 
-@app.get("/run-activity-feed")
+@app.get("/cardio-activity-feed")
 def read_activity_feed(
     start: date = DEFAULT_START,
     end: date = DEFAULT_END,

--- a/fitness/app/app.py
+++ b/fitness/app/app.py
@@ -18,6 +18,7 @@ from fitness.db.runs import get_runs_for_date_range
 from fitness.models import Run
 from fitness.models.run import LocalizedRun
 from fitness.models.run_detail import RunDetail
+from fitness.models.ride_detail import RideDetail
 from fitness.app.routers.run_workouts import (
     ActivityFeedRideItem,
     ActivityFeedRunItem,
@@ -235,13 +236,13 @@ def read_run_details_alt(
     )
 
 
-@app.get("/rides-details", response_model=list)
+@app.get("/rides-details", response_model=list[RideDetail])
 def read_ride_details(
     start: date = DEFAULT_START,
     end: date = DEFAULT_END,
     synced: bool | None = None,
     _user: User = Depends(require_viewer),
-):
+) -> list[RideDetail]:
     """Get detailed rides with sync info, sorted by datetime descending.
 
     Optional `synced` filter mirrors `/runs-details`: True for synced rides,

--- a/fitness/app/app.py
+++ b/fitness/app/app.py
@@ -28,6 +28,7 @@ from .routers import (
     metrics_router,
     shoe_router,
     ride_router,
+    ride_sync_router,
     run_router,
     sync_router,
     oauth_router,
@@ -122,6 +123,7 @@ app.include_router(metrics_router)
 app.include_router(shoe_router)
 app.include_router(run_router)
 app.include_router(ride_router)
+app.include_router(ride_sync_router)
 app.include_router(sync_router)
 app.include_router(oauth_router)
 app.include_router(strava_router)
@@ -233,6 +235,28 @@ def read_run_details_alt(
     )
 
 
+@app.get("/rides-details", response_model=list)
+def read_ride_details(
+    start: date = DEFAULT_START,
+    end: date = DEFAULT_END,
+    synced: bool | None = None,
+    _user: User = Depends(require_viewer),
+):
+    """Get detailed rides with sync info, sorted by datetime descending.
+
+    Optional `synced` filter mirrors `/runs-details`: True for synced rides,
+    False for unsynced (or never-synced) rides.
+    """
+    from fitness.db.rides import (
+        get_all_ride_details,
+        get_ride_details_in_date_range,
+    )
+
+    if start != DEFAULT_START or end != DEFAULT_END:
+        return get_ride_details_in_date_range(start, end, synced=synced)
+    return get_all_ride_details(synced=synced)
+
+
 @app.get("/cardio-activity-feed")
 def read_activity_feed(
     start: date = DEFAULT_START,
@@ -250,14 +274,16 @@ def read_activity_feed(
     in that timezone and the feed is filtered by each activity's local date.
     """
     from fitness.db.runs import get_run_details_in_date_range, get_all_run_details
-    from fitness.db.rides import get_rides_for_date_range, get_all_rides
+    from fitness.db.rides import get_ride_details_in_date_range, get_all_ride_details
     from fitness.app.routers.run_workouts import build_activity_feed
 
     if start != DEFAULT_START or end != DEFAULT_END:
         all_runs = get_run_details_in_date_range(
             start, end, user_timezone=user_timezone
         )
-        rides = get_rides_for_date_range(start, end, user_timezone=user_timezone)
+        rides = get_ride_details_in_date_range(
+            start, end, user_timezone=user_timezone
+        )
         if user_timezone is not None:
             tz = ZoneInfo(user_timezone)
             all_runs = [
@@ -276,7 +302,7 @@ def read_activity_feed(
             ]
     else:
         all_runs = get_all_run_details()
-        rides = get_all_rides()
+        rides = get_all_ride_details()
 
     return build_activity_feed(all_runs, rides=rides, sort_order=sort_order)
 

--- a/fitness/app/routers/__init__.py
+++ b/fitness/app/routers/__init__.py
@@ -1,5 +1,6 @@
 from .metrics import router as metrics_router
 from .shoes import router as shoe_router
+from .ride import router as ride_router
 from .run import router as run_router
 from .sync import router as sync_router
 from .oauth import router as oauth_router
@@ -17,6 +18,7 @@ __all__ = [
     "metrics_router",
     "shoe_router",
     "oauth_router",
+    "ride_router",
     "run_router",
     "sync_router",
     "strava_router",

--- a/fitness/app/routers/__init__.py
+++ b/fitness/app/routers/__init__.py
@@ -1,6 +1,7 @@
 from .metrics import router as metrics_router
 from .shoes import router as shoe_router
 from .ride import router as ride_router
+from .ride_sync import router as ride_sync_router
 from .run import router as run_router
 from .sync import router as sync_router
 from .oauth import router as oauth_router
@@ -19,6 +20,7 @@ __all__ = [
     "shoe_router",
     "oauth_router",
     "ride_router",
+    "ride_sync_router",
     "run_router",
     "sync_router",
     "strava_router",

--- a/fitness/app/routers/metrics.py
+++ b/fitness/app/routers/metrics.py
@@ -11,6 +11,7 @@ from fitness.agg import (
     training_stress_balance,
 )
 from fitness.db.runs import get_runs_for_date_range, get_all_runs
+from fitness.db.rides import get_rides_for_date_range, get_all_rides
 from fitness.db.shoes import get_shoes
 from fitness.agg.training_load import hrtss_by_day
 from fitness.app.constants import DEFAULT_START, DEFAULT_END
@@ -131,12 +132,12 @@ def read_training_load_by_day(
 ) -> list[DayTrainingLoad]:
     """Get training load by day.
 
-    Computes CTL/ATL/TSB over the specified range using hrTSS (heart-rate-enabled runs).
-    Needs full history for ATL/CTL convergence.
+    Computes CTL/ATL/TSB over the specified range using hrTSS from
+    HR-bearing runs and rides combined. Needs full history for ATL/CTL convergence.
     """
-    runs = get_all_runs()
+    activities = [*get_all_runs(), *get_all_rides()]
     return training_stress_balance(
-        runs=runs,
+        activities=activities,
         max_hr=max_hr,
         resting_hr=resting_hr,
         lthr=lthr,
@@ -160,8 +161,14 @@ def read_hrtss_by_day(
 ) -> list[dict]:
     """Get hrTSS values by day.
 
-    Returns a list of dicts with keys {"date", "hrtss"} for each day.
+    Returns a list of dicts with keys {"date", "hrtss"} for each day. Combines
+    hrTSS contributions from both runs and rides on each day.
     """
-    runs = get_runs_for_date_range(start, end, user_timezone)
-    day_hrtss = hrtss_by_day(runs, start, end, max_hr, resting_hr, lthr, sex, user_timezone)
+    activities = [
+        *get_runs_for_date_range(start, end, user_timezone),
+        *get_rides_for_date_range(start, end, user_timezone),
+    ]
+    day_hrtss = hrtss_by_day(
+        activities, start, end, max_hr, resting_hr, lthr, sex, user_timezone
+    )
     return [{"date": dt.date, "hrtss": dt.hrtss} for dt in day_hrtss]

--- a/fitness/app/routers/ride.py
+++ b/fitness/app/routers/ride.py
@@ -1,0 +1,93 @@
+"""CRUD routes for rides (currently: PATCH only)."""
+
+import logging
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from fitness.app.auth import require_editor
+from fitness.db.rides import get_ride_by_id, update_ride
+from fitness.models import Ride
+from fitness.models.user import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/rides", tags=["ride-editing"])
+
+
+class RideUpdateRequest(BaseModel):
+    """Request model for updating a ride.
+
+    All fields are optional; only fields explicitly set are applied. The
+    backend rejects post-update states where an Outdoor Ride has no
+    positive distance.
+    """
+
+    type: Literal["Outdoor Ride", "Indoor Ride"] | None = None
+    distance: float | None = Field(None, ge=0, description="Distance in miles")
+    duration: float | None = Field(None, ge=0, description="Duration in seconds")
+    avg_heart_rate: float | None = Field(
+        None, ge=0, le=220, description="Average heart rate"
+    )
+    datetime_utc: datetime | None = Field(
+        None, description="When the ride occurred (UTC)"
+    )
+
+
+class RideUpdateResponse(BaseModel):
+    """Response model for ride update operations."""
+
+    status: str
+    message: str
+    ride: Ride
+
+
+@router.patch("/{ride_id}", response_model=RideUpdateResponse)
+def update_ride_endpoint(
+    ride_id: str,
+    update_request: RideUpdateRequest,
+    _user: User = Depends(require_editor),
+) -> RideUpdateResponse:
+    """Update a ride.
+
+    Indoor and outdoor rides share the same shape; the type field
+    determines whether distance is meaningful. An update that leaves the
+    ride as an Outdoor Ride with `distance <= 0` is rejected.
+    """
+    existing = get_ride_by_id(ride_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Ride {ride_id} not found",
+        )
+
+    updates = update_request.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields provided for update",
+        )
+
+    # Validate post-update invariant: Outdoor Ride must have a positive distance.
+    final_type = updates.get("type", existing.type)
+    final_distance = updates.get("distance", existing.distance)
+    if final_type == "Outdoor Ride" and final_distance <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Outdoor Ride requires a positive distance",
+        )
+
+    try:
+        updated = update_ride(ride_id, updates)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
+
+    return RideUpdateResponse(
+        status="success",
+        message="Ride updated",
+        ride=updated,
+    )

--- a/fitness/app/routers/ride_sync.py
+++ b/fitness/app/routers/ride_sync.py
@@ -1,0 +1,130 @@
+"""Google Calendar sync routes for rides."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from fitness.app.auth import require_editor, require_viewer
+from fitness.db.rides import get_ride_by_id
+from fitness.db.synced_rides import (
+    create_synced_ride,
+    delete_synced_ride,
+    get_all_synced_rides,
+    get_failed_ride_syncs,
+    get_synced_ride,
+    update_synced_ride,
+)
+from fitness.models.sync import (
+    SyncedRide,
+    SyncResponse,
+    SyncRideStatusResponse,
+)
+from fitness.models.user import User
+from ._sync_helpers import perform_sync, perform_unsync
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/sync", tags=["ride-sync"])
+
+
+@router.get("/rides/{ride_id}/status", response_model=SyncRideStatusResponse)
+def get_ride_sync_status(
+    ride_id: str,
+    _user: User = Depends(require_viewer),
+) -> SyncRideStatusResponse:
+    """Get the Google Calendar sync status for a specific ride."""
+    synced = get_synced_ride(ride_id)
+    if synced is None:
+        return SyncRideStatusResponse(
+            ride_id=ride_id,
+            is_synced=False,
+            sync_status=None,
+            synced_at=None,
+            google_event_id=None,
+            ride_version=None,
+            error_message=None,
+        )
+    return SyncRideStatusResponse(
+        ride_id=ride_id,
+        is_synced=synced.sync_status == "synced",
+        sync_status=synced.sync_status,
+        synced_at=synced.synced_at,
+        google_event_id=synced.google_event_id,
+        ride_version=synced.ride_version,
+        error_message=synced.error_message,
+    )
+
+
+@router.post("/rides/{ride_id}", response_model=SyncResponse)
+def sync_ride_to_calendar(
+    ride_id: str,
+    _user: User = Depends(require_editor),
+) -> SyncResponse:
+    """Sync a ride to Google Calendar."""
+    existing_sync = get_synced_ride(ride_id)
+
+    ride = get_ride_by_id(ride_id)
+    if ride is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Ride {ride_id} not found",
+        )
+
+    return perform_sync(
+        entity_id=ride_id,
+        entity_type="ride",
+        existing_sync=existing_sync,
+        create_calendar_event=lambda client: client.create_ride_event(ride),
+        create_sync_record=lambda gid, s: create_synced_ride(
+            ride_id=ride_id,
+            google_event_id=gid,
+            ride_version=1,
+            sync_status=s,
+        ),
+        update_sync_record=lambda gid: update_synced_ride(
+            ride_id=ride_id,
+            google_event_id=gid,
+            sync_status="synced",
+            clear_error_message=True,
+        ),
+        record_failure=lambda gid, msg: (
+            update_synced_ride(ride_id=ride_id, sync_status="failed", error_message=msg)
+            if existing_sync
+            else create_synced_ride(
+                ride_id=ride_id,
+                google_event_id=gid or "",
+                sync_status="failed",
+                error_message=msg,
+            )
+        ),
+    )
+
+
+@router.delete("/rides/{ride_id}", response_model=SyncResponse)
+def unsync_ride_from_calendar(
+    ride_id: str,
+    _user: User = Depends(require_editor),
+) -> SyncResponse:
+    """Remove a ride's sync from Google Calendar."""
+    return perform_unsync(
+        entity_id=ride_id,
+        entity_type="ride",
+        synced_record=get_synced_ride(ride_id),
+        delete_sync_record=lambda: delete_synced_ride(ride_id),
+    )
+
+
+@router.get("/rides", response_model=list[SyncedRide])
+def get_all_ride_sync_records(
+    _user: User = Depends(require_viewer),
+) -> list[SyncedRide]:
+    """Get all ride sync records (admin/debugging)."""
+    return get_all_synced_rides()
+
+
+@router.get("/rides/failed", response_model=list[SyncedRide])
+def get_failed_ride_sync_records(
+    _user: User = Depends(require_viewer),
+) -> list[SyncedRide]:
+    """Get all rides with failed sync status."""
+    return get_failed_ride_syncs()

--- a/fitness/app/routers/run_workouts.py
+++ b/fitness/app/routers/run_workouts.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, field_validator
 
 from fitness.app.auth import require_viewer, require_editor
 from fitness.models.user import User
-from fitness.models.ride import Ride
+from fitness.models.ride_detail import RideDetail
 from fitness.models.run_detail import RunDetail
 from fitness.models.run_workout import RunWorkout, RunWorkoutDetail
 from fitness.db.synced_run_workouts import (
@@ -115,7 +115,7 @@ class ActivityFeedWorkoutItem(BaseModel):
 
 class ActivityFeedRideItem(BaseModel):
     type: Literal["ride"] = "ride"
-    item: Ride
+    item: RideDetail
 
 
 def _reject_if_workout_synced(workout_id: str) -> None:
@@ -236,7 +236,7 @@ async def remove_workout(
 
 def build_activity_feed(
     all_runs: list[RunDetail],
-    rides: list[Ride] | None = None,
+    rides: list[RideDetail] | None = None,
     sort_order: str = "desc",
 ) -> list[ActivityFeedRunItem | ActivityFeedWorkoutItem | ActivityFeedRideItem]:
     """Build a unified cardio activity feed from runs and rides.

--- a/fitness/app/routers/run_workouts.py
+++ b/fitness/app/routers/run_workouts.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, field_validator
 
 from fitness.app.auth import require_viewer, require_editor
 from fitness.models.user import User
+from fitness.models.ride import Ride
 from fitness.models.run_detail import RunDetail
 from fitness.models.run_workout import RunWorkout, RunWorkoutDetail
 from fitness.db.synced_run_workouts import (
@@ -110,6 +111,11 @@ class ActivityFeedRunItem(BaseModel):
 class ActivityFeedWorkoutItem(BaseModel):
     type: Literal["run_workout"] = "run_workout"
     item: RunWorkoutDetail
+
+
+class ActivityFeedRideItem(BaseModel):
+    type: Literal["ride"] = "ride"
+    item: Ride
 
 
 def _reject_if_workout_synced(workout_id: str) -> None:
@@ -230,12 +236,14 @@ async def remove_workout(
 
 def build_activity_feed(
     all_runs: list[RunDetail],
+    rides: list[Ride] | None = None,
     sort_order: str = "desc",
-) -> list[ActivityFeedRunItem | ActivityFeedWorkoutItem]:
-    """Build a unified activity feed from a list of run details.
+) -> list[ActivityFeedRunItem | ActivityFeedWorkoutItem | ActivityFeedRideItem]:
+    """Build a unified cardio activity feed from runs and rides.
 
-    Partitions runs into solo runs and workout-grouped runs, computes
-    workout aggregates, and returns a sorted feed.
+    Partitions runs into solo runs and workout-grouped runs, computes workout
+    aggregates, appends rides as solo items (rides are not grouped), and
+    returns the combined feed sorted by datetime.
     """
     # Partition into solo runs and workout-grouped runs
     solo_runs: list[RunDetail] = []
@@ -247,7 +255,9 @@ def build_activity_feed(
             solo_runs.append(run)
 
     # Build feed items
-    feed: list[ActivityFeedRunItem | ActivityFeedWorkoutItem] = []
+    feed: list[
+        ActivityFeedRunItem | ActivityFeedWorkoutItem | ActivityFeedRideItem
+    ] = []
 
     # Add solo runs
     for run in solo_runs:
@@ -276,13 +286,17 @@ def build_activity_feed(
                 detail.google_event_id = sync_record.google_event_id
             feed.append(ActivityFeedWorkoutItem(item=detail))
 
+    # Add rides (always solo — no ride workouts in v1)
+    for ride in rides or []:
+        feed.append(ActivityFeedRideItem(item=ride))
+
     # Sort by effective datetime
     def sort_key(
-        item: ActivityFeedRunItem | ActivityFeedWorkoutItem,
+        item: ActivityFeedRunItem | ActivityFeedWorkoutItem | ActivityFeedRideItem,
     ) -> datetime:
-        if isinstance(item, ActivityFeedRunItem):
-            return item.item.datetime_utc
-        return item.item.start_datetime_utc
+        if isinstance(item, ActivityFeedWorkoutItem):
+            return item.item.start_datetime_utc
+        return item.item.datetime_utc
 
     reverse = sort_order == "desc"
     feed.sort(key=sort_key, reverse=reverse)

--- a/fitness/app/routers/strava.py
+++ b/fitness/app/routers/strava.py
@@ -9,10 +9,11 @@ from fitness.app.auth import require_editor
 from fitness.models.user import User
 from fitness.models.responses import DataImportResponse
 from fitness.integrations.strava.client import StravaClient
-from fitness.models import Run
+from fitness.models import Run, Ride
 from fitness.db.runs import get_existing_run_ids, bulk_create_runs
+from fitness.db.rides import get_existing_ride_ids, bulk_create_rides
 from fitness.db.sync_metadata import get_last_sync_time, update_last_sync_time
-from fitness.load.strava import load_strava_runs
+from fitness.load.strava import load_strava_runs, load_strava_rides
 
 logger = logging.getLogger(__name__)
 
@@ -54,23 +55,33 @@ async def sync_strava_data(
     # Record sync start time before fetching
     sync_time = datetime.now(timezone.utc)
 
-    # Get Strava runs from the API (with optional after filter)
+    # Runs ingestion
     strava_runs = [
         Run.from_strava(run) for run in load_strava_runs(strava_client, after=after)
     ]
-
-    # Get the IDs of all existing runs in the db.
     existing_run_ids = get_existing_run_ids()
-
-    # Filter to only new runs (double-check even with incremental sync)
     new_runs = [run for run in strava_runs if run.id not in existing_run_ids]
-
     if new_runs:
-        inserted_count = bulk_create_runs(new_runs)
-        logger.info(f"Inserted {inserted_count} new runs into the database")
+        inserted_runs = bulk_create_runs(new_runs)
+        logger.info(f"Inserted {inserted_runs} new runs into the database")
     else:
-        inserted_count = 0
+        inserted_runs = 0
         logger.info("No new runs to insert")
+
+    # Rides ingestion
+    strava_rides = [
+        Ride.from_strava(ride) for ride in load_strava_rides(strava_client, after=after)
+    ]
+    existing_ride_ids = get_existing_ride_ids()
+    new_rides = [ride for ride in strava_rides if ride.id not in existing_ride_ids]
+    if new_rides:
+        inserted_rides = bulk_create_rides(new_rides)
+        logger.info(f"Inserted {inserted_rides} new rides into the database")
+    else:
+        inserted_rides = 0
+        logger.info("No new rides to insert")
+
+    inserted_count = inserted_runs + inserted_rides
 
     # Update last sync time on successful completion
     update_last_sync_time(PROVIDER_NAME, sync_time)
@@ -78,8 +89,13 @@ async def sync_strava_data(
     sync_type = "full" if full_sync or after is None else "incremental"
     return DataImportResponse(
         inserted_count=inserted_count,
+        inserted_runs=inserted_runs,
+        inserted_rides=inserted_rides,
         updated_at=sync_time,
-        message=f"Inserted {inserted_count} new runs ({sync_type} sync)",
+        message=(
+            f"Inserted {inserted_runs} new runs and {inserted_rides} new rides "
+            f"({sync_type} sync)"
+        ),
     )
 
 

--- a/fitness/app/routers/summary.py
+++ b/fitness/app/routers/summary.py
@@ -60,7 +60,7 @@ def get_trmnl_summary(
 
     # Calculate training load series for the last 60 days
     training_load_data = training_stress_balance(
-        runs=runs,
+        activities=runs,
         max_hr=max_hr,
         resting_hr=resting_hr,
         lthr=lthr,

--- a/fitness/db/rides.py
+++ b/fitness/db/rides.py
@@ -109,6 +109,69 @@ def bulk_create_rides(rides: list[Ride], chunk_size: int = 20) -> int:
     return total_inserted
 
 
+def get_ride_by_id(ride_id: str, include_deleted: bool = False) -> Ride | None:
+    """Get a single ride by its ID."""
+    with get_db_cursor() as cursor:
+        deleted_filter = (
+            sql.SQL("") if include_deleted else sql.SQL(" AND deleted_at IS NULL")
+        )
+        query = sql.SQL("""
+            SELECT id, datetime_utc, type, distance, duration, source, avg_heart_rate, deleted_at
+            FROM rides
+            WHERE id = %s{deleted_filter}
+        """).format(deleted_filter=deleted_filter)
+        cursor.execute(query, (ride_id,))
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return _row_to_ride(row)
+
+
+_UPDATABLE_RIDE_FIELDS: tuple[str, ...] = (
+    "datetime_utc",
+    "type",
+    "distance",
+    "duration",
+    "avg_heart_rate",
+)
+
+
+def update_ride(ride_id: str, updates: dict) -> Ride:
+    """Apply field-level updates to a ride and return the updated row.
+
+    Raises ValueError if the ride is not found or no valid fields are provided.
+    Only fields in `_UPDATABLE_RIDE_FIELDS` are honored.
+    """
+    if not updates:
+        raise ValueError("No updates provided")
+
+    set_fields = [f for f in _UPDATABLE_RIDE_FIELDS if f in updates]
+    if not set_fields:
+        raise ValueError("No updatable fields provided")
+
+    set_assignments = sql.SQL(", ").join(
+        sql.SQL("{} = {}").format(sql.Identifier(f), sql.Placeholder())
+        for f in set_fields
+    )
+    query = sql.SQL(
+        "UPDATE rides SET {set_assignments}, updated_at = CURRENT_TIMESTAMP "
+        "WHERE id = {id} AND deleted_at IS NULL"
+    ).format(set_assignments=set_assignments, id=sql.Placeholder())
+    params = [updates[f] for f in set_fields] + [ride_id]
+
+    with get_db_connection() as conn:
+        with conn.transaction():
+            with conn.cursor() as cursor:
+                cursor.execute(query, params)
+                if cursor.rowcount == 0:
+                    raise ValueError(f"Ride {ride_id} not found")
+
+    updated = get_ride_by_id(ride_id)
+    if updated is None:  # Should be unreachable given rowcount check above.
+        raise ValueError(f"Ride {ride_id} not found after update")
+    return updated
+
+
 def get_existing_ride_ids() -> set[str]:
     """Get all existing (non-deleted) ride IDs from the database."""
     with get_db_cursor() as cursor:

--- a/fitness/db/rides.py
+++ b/fitness/db/rides.py
@@ -1,0 +1,142 @@
+import logging
+from datetime import date, timedelta
+
+from psycopg import sql
+
+from fitness.models import Ride
+from .connection import get_db_cursor, get_db_connection
+
+logger = logging.getLogger(__name__)
+
+
+def get_all_rides(include_deleted: bool = False) -> list[Ride]:
+    """Get all rides from the database."""
+    with get_db_cursor() as cursor:
+        deleted_filter = (
+            sql.SQL("") if include_deleted else sql.SQL(" WHERE deleted_at IS NULL")
+        )
+        query = sql.SQL("""
+            SELECT id, datetime_utc, type, distance, duration, source, avg_heart_rate, deleted_at
+            FROM rides
+            {deleted_filter}
+            ORDER BY datetime_utc
+        """).format(deleted_filter=deleted_filter)
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        return [_row_to_ride(row) for row in rows]
+
+
+def get_rides_in_date_range(
+    start_date: date,
+    end_date: date,
+    include_deleted: bool = False,
+) -> list[Ride]:
+    """Get rides within a UTC date range."""
+    with get_db_cursor() as cursor:
+        deleted_filter = sql.SQL("")
+        if not include_deleted:
+            deleted_filter = sql.SQL(" AND deleted_at IS NULL")
+        query = sql.SQL("""
+            SELECT id, datetime_utc, type, distance, duration, source,
+                   avg_heart_rate, deleted_at
+            FROM rides
+            WHERE DATE(datetime_utc) BETWEEN %s AND %s{deleted_filter}
+            ORDER BY datetime_utc
+        """).format(deleted_filter=deleted_filter)
+        cursor.execute(query, [start_date, end_date])
+        rows = cursor.fetchall()
+        return [_row_to_ride(row) for row in rows]
+
+
+def get_rides_for_date_range(
+    start: date,
+    end: date,
+    user_timezone: str | None = None,
+) -> list[Ride]:
+    """Fetch rides for a date range, widening by 1 day when timezone conversion is needed.
+
+    Mirrors `get_runs_for_date_range`: when user_timezone is set, the SQL query
+    is widened by ±1 day to account for UTC-to-local date offset. Callers do
+    exact filtering in Python after timezone conversion.
+    """
+    if user_timezone is not None:
+        return get_rides_in_date_range(
+            start - timedelta(days=1), end + timedelta(days=1)
+        )
+    return get_rides_in_date_range(start, end)
+
+
+def bulk_create_rides(rides: list[Ride], chunk_size: int = 20) -> int:
+    """Insert multiple rides into the database in chunks. Returns the number of inserted rows."""
+    if not rides:
+        return 0
+
+    logger.info(f"Starting bulk insert of {len(rides)} rides in chunks of {chunk_size}")
+
+    total_inserted = 0
+    with get_db_connection() as conn:
+        with conn.transaction():
+            with conn.cursor() as cursor:
+                for i in range(0, len(rides), chunk_size):
+                    chunk = rides[i : i + chunk_size]
+                    ride_data = [
+                        (
+                            ride.id,
+                            ride.datetime_utc,
+                            ride.type,
+                            ride.distance,
+                            ride.duration,
+                            ride.source,
+                            ride.avg_heart_rate,
+                            ride.deleted_at,
+                        )
+                        for ride in chunk
+                    ]
+                    cursor.executemany(
+                        """
+                        INSERT INTO rides (id, datetime_utc, type, distance, duration, source, avg_heart_rate, deleted_at)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        ride_data,
+                    )
+                    chunk_inserted = cursor.rowcount
+                    total_inserted += chunk_inserted
+                    logger.info(
+                        f"Inserted {chunk_inserted} rides in chunk {i // chunk_size + 1} (rides {i + 1}-{min(i + chunk_size, len(rides))})"
+                    )
+
+    logger.info(f"Bulk insert completed: {total_inserted} total rides inserted")
+    return total_inserted
+
+
+def get_existing_ride_ids() -> set[str]:
+    """Get all existing (non-deleted) ride IDs from the database."""
+    with get_db_cursor() as cursor:
+        cursor.execute("SELECT id FROM rides WHERE deleted_at IS NULL")
+        rows = cursor.fetchall()
+        existing_ids = {row[0] for row in rows}
+        logger.info(f"Found {len(existing_ids)} existing ride IDs in database")
+        return existing_ids
+
+
+def _row_to_ride(row) -> Ride:
+    (
+        ride_id,
+        datetime_utc,
+        type_,
+        distance,
+        duration,
+        source,
+        avg_heart_rate,
+        deleted_at,
+    ) = row
+    return Ride(
+        id=ride_id,
+        datetime_utc=datetime_utc,
+        type=type_,
+        distance=distance,
+        duration=duration,
+        source=source,
+        avg_heart_rate=avg_heart_rate,
+        deleted_at=deleted_at,
+    )

--- a/fitness/db/rides.py
+++ b/fitness/db/rides.py
@@ -4,9 +4,54 @@ from datetime import date, timedelta
 from psycopg import sql
 
 from fitness.models import Ride
+from fitness.models.ride_detail import RideDetail
 from .connection import get_db_cursor, get_db_connection
 
 logger = logging.getLogger(__name__)
+
+
+_RIDE_DETAIL_SELECT = sql.SQL("""
+    SELECT r.id, r.datetime_utc, r.type, r.distance, r.duration, r.source,
+           r.avg_heart_rate, r.deleted_at,
+           sr.sync_status, sr.synced_at, sr.google_event_id,
+           sr.ride_version, sr.error_message
+    FROM rides r
+    LEFT JOIN synced_rides sr ON sr.ride_id = r.id
+""")
+
+
+def _row_to_ride_detail(row) -> RideDetail:
+    (
+        ride_id,
+        datetime_utc,
+        type_,
+        distance,
+        duration,
+        source,
+        avg_heart_rate,
+        deleted_at,
+        sync_status,
+        synced_at,
+        google_event_id,
+        synced_version,
+        error_message,
+    ) = row
+    return RideDetail(
+        id=ride_id,
+        datetime_utc=datetime_utc,
+        type=type_,
+        distance=distance,
+        duration=duration,
+        source=source,
+        avg_heart_rate=avg_heart_rate,
+        deleted_at=deleted_at,
+        is_synced=(sync_status == "synced"),
+        sync_status=sync_status,
+        synced_at=synced_at,
+        google_event_id=google_event_id or None,
+        synced_version=synced_version,
+        error_message=error_message,
+    )
 
 
 def get_all_rides(include_deleted: bool = False) -> list[Ride]:
@@ -107,6 +152,88 @@ def bulk_create_rides(rides: list[Ride], chunk_size: int = 20) -> int:
 
     logger.info(f"Bulk insert completed: {total_inserted} total rides inserted")
     return total_inserted
+
+
+def get_ride_details_in_date_range(
+    start_date: date,
+    end_date: date,
+    include_deleted: bool = False,
+    synced: bool | None = None,
+    user_timezone: str | None = None,
+) -> list[RideDetail]:
+    """Get rides with sync info within a UTC date range.
+
+    When `user_timezone` is set, the SQL range is widened by ±1 day; callers
+    must do exact local-date filtering after this returns.
+    """
+    if user_timezone is not None:
+        start_date = start_date - timedelta(days=1)
+        end_date = end_date + timedelta(days=1)
+
+    conditions: list[sql.Composable] = [
+        sql.SQL("DATE(r.datetime_utc) BETWEEN %s AND %s")
+    ]
+    params: list = [start_date, end_date]
+    if not include_deleted:
+        conditions.append(sql.SQL("r.deleted_at IS NULL"))
+    if synced is True:
+        conditions.append(sql.SQL("sr.sync_status = 'synced'"))
+    elif synced is False:
+        conditions.append(
+            sql.SQL("(sr.sync_status IS DISTINCT FROM 'synced' OR sr.ride_id IS NULL)")
+        )
+
+    where_clause = sql.SQL(" AND ").join(conditions)
+    query = sql.SQL("{select} WHERE {where} ORDER BY r.datetime_utc DESC").format(
+        select=_RIDE_DETAIL_SELECT, where=where_clause
+    )
+    with get_db_cursor() as cursor:
+        cursor.execute(query, params)
+        return [_row_to_ride_detail(row) for row in cursor.fetchall()]
+
+
+def get_all_ride_details(
+    include_deleted: bool = False,
+    synced: bool | None = None,
+) -> list[RideDetail]:
+    conditions: list[sql.Composable] = []
+    if not include_deleted:
+        conditions.append(sql.SQL("r.deleted_at IS NULL"))
+    if synced is True:
+        conditions.append(sql.SQL("sr.sync_status = 'synced'"))
+    elif synced is False:
+        conditions.append(
+            sql.SQL("(sr.sync_status IS DISTINCT FROM 'synced' OR sr.ride_id IS NULL)")
+        )
+
+    where_clause = (
+        sql.SQL("WHERE ") + sql.SQL(" AND ").join(conditions)
+        if conditions
+        else sql.SQL("")
+    )
+    query = sql.SQL("{select} {where} ORDER BY r.datetime_utc DESC").format(
+        select=_RIDE_DETAIL_SELECT, where=where_clause
+    )
+    with get_db_cursor() as cursor:
+        cursor.execute(query)
+        return [_row_to_ride_detail(row) for row in cursor.fetchall()]
+
+
+def get_ride_detail_by_id(
+    ride_id: str, include_deleted: bool = False
+) -> RideDetail | None:
+    deleted_filter = (
+        sql.SQL("") if include_deleted else sql.SQL(" AND r.deleted_at IS NULL")
+    )
+    query = sql.SQL("{select} WHERE r.id = %s{deleted_filter}").format(
+        select=_RIDE_DETAIL_SELECT, deleted_filter=deleted_filter
+    )
+    with get_db_cursor() as cursor:
+        cursor.execute(query, (ride_id,))
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return _row_to_ride_detail(row)
 
 
 def get_ride_by_id(ride_id: str, include_deleted: bool = False) -> Ride | None:

--- a/fitness/db/synced_rides.py
+++ b/fitness/db/synced_rides.py
@@ -1,0 +1,190 @@
+"""Database access functions for synced rides (Google Calendar sync tracking)."""
+
+import logging
+from datetime import datetime, timezone
+
+from psycopg import sql
+
+from fitness.models.sync import SyncedRide, SyncStatus
+from .connection import get_db_cursor
+
+logger = logging.getLogger(__name__)
+
+
+def _row_to_synced_ride(row: tuple) -> SyncedRide:
+    (
+        sync_id,
+        ride_id,
+        ride_version,
+        google_event_id,
+        synced_at,
+        sync_status,
+        error_message,
+        created_at,
+        updated_at,
+    ) = row
+    return SyncedRide(
+        id=sync_id,
+        ride_id=ride_id,
+        ride_version=ride_version,
+        google_event_id=google_event_id,
+        synced_at=synced_at,
+        sync_status=sync_status,
+        error_message=error_message,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+def get_synced_ride(ride_id: str) -> SyncedRide | None:
+    """Get sync record for a specific ride."""
+    with get_db_cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT id, ride_id, ride_version, google_event_id, synced_at,
+                   sync_status, error_message, created_at, updated_at
+            FROM synced_rides
+            WHERE ride_id = %s
+            """,
+            (ride_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_synced_ride(row)
+
+
+def create_synced_ride(
+    ride_id: str,
+    google_event_id: str,
+    ride_version: int = 1,
+    sync_status: SyncStatus = "synced",
+    error_message: str | None = None,
+) -> SyncedRide:
+    """Create a new sync record for a ride."""
+    logger.info(
+        f"Creating sync record: ride_id={ride_id}, google_event_id={google_event_id}, "
+        f"sync_status={sync_status}, ride_version={ride_version}"
+    )
+    with get_db_cursor() as cursor:
+        now = datetime.now(timezone.utc)
+        cursor.execute(
+            """
+            INSERT INTO synced_rides
+            (ride_id, ride_version, google_event_id, synced_at, sync_status, error_message, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id, created_at, updated_at
+            """,
+            (
+                ride_id,
+                ride_version,
+                google_event_id,
+                now,
+                sync_status,
+                error_message,
+                now,
+                now,
+            ),
+        )
+        result = cursor.fetchone()
+        if result is None:
+            raise RuntimeError(f"Failed to create sync record for ride_id={ride_id}")
+        sync_id, created_at, updated_at = result
+
+        return SyncedRide(
+            id=sync_id,
+            ride_id=ride_id,
+            ride_version=ride_version,
+            google_event_id=google_event_id,
+            synced_at=now,
+            sync_status=sync_status,
+            error_message=error_message,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+
+def update_synced_ride(
+    ride_id: str,
+    ride_version: int | None = None,
+    google_event_id: str | None = None,
+    sync_status: SyncStatus | None = None,
+    error_message: str | None = None,
+    clear_error_message: bool = False,
+) -> SyncedRide | None:
+    """Update an existing sync record. Returns None if not found."""
+    update_fields: list[sql.Composable] = []
+    params: list = []
+
+    if ride_version is not None:
+        update_fields.append(sql.SQL("ride_version = %s"))
+        params.append(ride_version)
+    if google_event_id is not None:
+        update_fields.append(sql.SQL("google_event_id = %s"))
+        params.append(google_event_id)
+    if sync_status is not None:
+        update_fields.append(sql.SQL("sync_status = %s"))
+        params.append(sync_status)
+    if error_message is not None:
+        update_fields.append(sql.SQL("error_message = %s"))
+        params.append(error_message)
+    elif clear_error_message:
+        update_fields.append(sql.SQL("error_message = NULL"))
+
+    if not update_fields:
+        return get_synced_ride(ride_id)
+
+    update_fields.append(sql.SQL("updated_at = %s"))
+    params.append(datetime.now(timezone.utc))
+    params.append(ride_id)
+
+    query = sql.SQL("""
+        UPDATE synced_rides
+        SET {update_fields}
+        WHERE ride_id = %s
+        RETURNING id, ride_id, ride_version, google_event_id, synced_at,
+                  sync_status, error_message, created_at, updated_at
+    """).format(update_fields=sql.SQL(", ").join(update_fields))
+
+    with get_db_cursor() as cursor:
+        cursor.execute(query, params)
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_synced_ride(row)
+
+
+def delete_synced_ride(ride_id: str) -> bool:
+    """Delete a sync record for a ride. Returns True if a row was deleted."""
+    with get_db_cursor() as cursor:
+        cursor.execute("DELETE FROM synced_rides WHERE ride_id = %s", (ride_id,))
+        return cursor.rowcount > 0
+
+
+def get_all_synced_rides() -> list[SyncedRide]:
+    with get_db_cursor() as cursor:
+        cursor.execute("""
+            SELECT id, ride_id, ride_version, google_event_id, synced_at,
+                   sync_status, error_message, created_at, updated_at
+            FROM synced_rides
+            ORDER BY synced_at DESC
+        """)
+        return [_row_to_synced_ride(row) for row in cursor.fetchall()]
+
+
+def is_ride_synced(ride_id: str) -> bool:
+    """Check if a ride is currently synced to Google Calendar."""
+    synced = get_synced_ride(ride_id)
+    return synced is not None and synced.sync_status == "synced"
+
+
+def get_failed_ride_syncs() -> list[SyncedRide]:
+    with get_db_cursor() as cursor:
+        cursor.execute("""
+            SELECT id, ride_id, ride_version, google_event_id, synced_at,
+                   sync_status, error_message, created_at, updated_at
+            FROM synced_rides
+            WHERE sync_status = 'failed'
+            ORDER BY updated_at DESC
+        """)
+        return [_row_to_synced_ride(row) for row in cursor.fetchall()]

--- a/fitness/integrations/google/calendar_client.py
+++ b/fitness/integrations/google/calendar_client.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict, Any
 
 import httpx
 from fitness.models.run import Run
+from fitness.models.ride import Ride
 from fitness.models.lift import Lift
 from fitness.models.run_workout import RunWorkout
 from fitness.db.oauth_credentials import get_credentials, update_access_token
@@ -309,6 +310,74 @@ class GoogleCalendarClient:
                 f"error_data={error_data}, response_text={error_text[:500]}"
             )
             return None
+
+    def create_ride_event(self, ride: Ride) -> Optional[str]:
+        """Create a calendar event for a cycling activity.
+
+        Title format mirrors the user's preference:
+            - "Indoor Bike Ride"
+            - "Outdoor Bike Ride"
+
+        The description carries duration, distance (when meaningful), and HR.
+        """
+        if ride.type == "Indoor Ride":
+            event_title = "Indoor Bike Ride"
+        else:
+            event_title = "Outdoor Bike Ride"
+
+        # Build a short description summarizing the ride.
+        duration_seconds_total = int(ride.duration) if ride.duration else 0
+        if duration_seconds_total < 0:
+            duration_seconds_total = 0
+        duration_minutes = duration_seconds_total // 60
+        duration_seconds = duration_seconds_total % 60
+        description_lines = [
+            f"Duration: {duration_minutes}:{duration_seconds:02d}",
+        ]
+        if ride.type == "Outdoor Ride" and ride.distance:
+            description_lines.append(f"Distance: {ride.distance:.2f} mi")
+        if ride.avg_heart_rate is not None:
+            description_lines.append(f"Avg HR: {ride.avg_heart_rate:.0f} bpm")
+        description_lines.append("")
+        description_lines.append(f"Synced from fitness app — Ride ID: {ride.id}")
+
+        # Convert stored UTC-naive datetime to timezone-aware UTC.
+        start_dt_utc = ride.datetime_utc.replace(tzinfo=timezone.utc)
+        end_dt_utc = start_dt_utc + timedelta(seconds=duration_seconds_total)
+
+        event_data = {
+            "summary": event_title,
+            "description": "\n".join(description_lines),
+            "start": {"dateTime": start_dt_utc.isoformat()},
+            "end": {"dateTime": end_dt_utc.isoformat()},
+        }
+
+        url = f"{self.base_url}/calendars/{self.calendar_id}/events"
+        response = self._make_request("POST", url, json=event_data)
+
+        if response and 200 <= response.status_code < 300:
+            event = response.json()
+            event_id = event.get("id")
+            logger.info(
+                f"Successfully created calendar event: ride_id={ride.id}, "
+                f"event_id={event_id}, calendar_id={self.calendar_id}"
+            )
+            return event_id
+
+        status_code = response.status_code if response else "N/A"
+        error_text = response.text if response else "No response received"
+        error_data = None
+        if response:
+            try:
+                error_data = response.json()
+            except Exception:
+                pass
+        logger.error(
+            f"Failed to create calendar event: ride_id={ride.id}, "
+            f"calendar_id={self.calendar_id}, status_code={status_code}, "
+            f"error_data={error_data}, response_text={error_text[:500]}"
+        )
+        return None
 
     def create_lift_event(self, lift: Lift) -> Optional[str]:
         """Create a calendar event for a weightlifting workout.

--- a/fitness/integrations/strava/models.py
+++ b/fitness/integrations/strava/models.py
@@ -13,7 +13,15 @@ class StravaAthlete(BaseModel):
 
 
 StravaActivityType = Literal[
-    "Workout", "Ride", "Walk", "Run", "Indoor Run", "Yoga", "WeightTraining", "Hike"
+    "Workout",
+    "Ride",
+    "VirtualRide",
+    "Walk",
+    "Run",
+    "Indoor Run",
+    "Yoga",
+    "WeightTraining",
+    "Hike",
 ]
 
 

--- a/fitness/load/strava.py
+++ b/fitness/load/strava.py
@@ -3,9 +3,47 @@ from datetime import datetime
 from typing import Optional
 
 from fitness.integrations.strava.client import StravaClient
-from fitness.integrations.strava.models import StravaActivityWithGear
+from fitness.integrations.strava.models import StravaActivity, StravaActivityWithGear
 
 logger = logging.getLogger(__name__)
+
+
+def load_strava_rides(
+    client: StravaClient, after: Optional[datetime] = None
+) -> list[StravaActivity]:
+    """Fetch outdoor (`Ride`) and indoor (`VirtualRide`) cycling activities.
+
+    Unlike runs, rides are not joined with gear in v1 (no bike tracking yet),
+    so this returns raw `StravaActivity` instances.
+
+    Args:
+        client: The Strava API client.
+        after: Only fetch activities after this datetime (for incremental sync).
+
+    Returns:
+        List of Strava cycling activities.
+    """
+    if after:
+        logger.info(
+            f"Starting Strava ride load (incremental, after {after.isoformat()})"
+        )
+    else:
+        logger.info("Starting Strava ride load (full sync)")
+
+    try:
+        activities = client.get_activities(after=after)
+        logger.info(f"Retrieved {len(activities)} total activities from Strava")
+        rides = [a for a in activities if a.type in ("Ride", "VirtualRide")]
+        logger.info(
+            f"Filtered to {len(rides)} rides (excluded {len(activities) - len(rides)} non-ride activities)"
+        )
+        return rides
+    except Exception as e:
+        logger.error(
+            f"Failed to load Strava rides: {type(e).__name__}: {str(e)}",
+            exc_info=True,
+        )
+        raise
 
 
 def load_strava_runs(

--- a/fitness/models/__init__.py
+++ b/fitness/models/__init__.py
@@ -1,4 +1,5 @@
 from .run import Run, RunType, RunSource, LocalizedRun
+from .ride import Ride, RideType, RideSource, LocalizedRide
 from .shoe import Shoe, ShoeMileage
 from .training_load import TrainingLoad, DayTrainingLoad
 from .sync import (
@@ -20,6 +21,10 @@ __all__ = [
     "RunType",
     "RunSource",
     "LocalizedRun",
+    "Ride",
+    "RideType",
+    "RideSource",
+    "LocalizedRide",
     "Shoe",
     "ShoeMileage",
     "TrainingLoad",

--- a/fitness/models/responses.py
+++ b/fitness/models/responses.py
@@ -8,7 +8,9 @@ from pydantic import BaseModel, Field
 class DataImportResponse(BaseModel):
     """Response model for data import operations (Strava, MMF, etc.)."""
 
-    inserted_count: int = Field(description="Number of runs inserted")
+    inserted_count: int = Field(
+        description="Total number of activities inserted (runs + rides)"
+    )
     updated_at: datetime = Field(description="When the import occurred")
     message: str = Field(description="Human-readable status message")
     total_runs_found: int | None = Field(
@@ -16,4 +18,10 @@ class DataImportResponse(BaseModel):
     )
     existing_runs: int | None = Field(
         default=None, description="Number of runs that already existed"
+    )
+    inserted_runs: int | None = Field(
+        default=None, description="Number of runs inserted"
+    )
+    inserted_rides: int | None = Field(
+        default=None, description="Number of rides inserted"
     )

--- a/fitness/models/ride.py
+++ b/fitness/models/ride.py
@@ -7,10 +7,7 @@ import zoneinfo
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
-    from fitness.integrations.strava.models import (
-        StravaActivity,
-        StravaActivityType,
-    )
+    from fitness.integrations.strava.models import StravaActivity
 
 
 RideType = Literal["Outdoor Ride", "Indoor Ride"]

--- a/fitness/models/ride.py
+++ b/fitness/models/ride.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from datetime import date, datetime, timezone
+from typing import Literal, Self
+import zoneinfo
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from fitness.integrations.strava.models import (
+        StravaActivity,
+        StravaActivityType,
+    )
+
+
+RideType = Literal["Outdoor Ride", "Indoor Ride"]
+RideSource = Literal["Strava"]
+
+# Map Strava activity types to our ride types.
+StravaRideMap: dict["StravaActivityType", RideType] = {
+    "Ride": "Outdoor Ride",
+    "VirtualRide": "Indoor Ride",
+}
+
+
+class Ride(BaseModel):
+    id: str  # Deterministic ID: f"strava_{strava_id}"
+    datetime_utc: datetime
+    type: RideType
+    distance: float  # in miles
+    duration: float  # in seconds (Strava elapsed_time)
+    source: RideSource
+    avg_heart_rate: float | None = None
+    deleted_at: datetime | None = None
+
+    @property
+    def is_deleted(self) -> bool:
+        """Check if the ride is soft-deleted."""
+        return self.deleted_at is not None
+
+    def soft_delete(self) -> None:
+        """Soft delete this ride."""
+        self.deleted_at = datetime.now(timezone.utc)
+
+    def restore(self) -> None:
+        """Restore a soft-deleted ride."""
+        self.deleted_at = None
+
+    def model_dump(self, **kwargs) -> dict:
+        """Override model_dump to include date field for parity with Run."""
+        data = super().model_dump(**kwargs)
+        data["date"] = (
+            self.datetime_utc.date() if self.datetime_utc is not None else None
+        )
+        return data
+
+    @classmethod
+    def from_strava(cls, strava_activity: "StravaActivity") -> Self:
+        """Create a Ride from a raw Strava activity.
+
+        Unlike Run.from_strava, takes StravaActivity directly (no gear lookup):
+        rides do not currently track bike gear.
+        """
+        return cls(
+            id=f"strava_{strava_activity.id}",
+            datetime_utc=strava_activity.start_date.replace(tzinfo=None),
+            type=StravaRideMap[strava_activity.type],
+            distance=strava_activity.distance * 0.000621371,  # meters -> miles
+            duration=strava_activity.elapsed_time,
+            avg_heart_rate=strava_activity.average_heartrate,
+            source="Strava",
+        )
+
+
+class LocalizedRide(Ride):
+    """A ride with its datetime converted to user's local timezone."""
+
+    localized_datetime: datetime
+
+    @property
+    def local_date(self) -> date:
+        """Get the local date for this ride."""
+        return self.localized_datetime.date()
+
+    @classmethod
+    def from_ride(cls, ride: Ride, user_timezone: str) -> Self:
+        """Create a LocalizedRide from a Ride by converting to user timezone."""
+        tz = zoneinfo.ZoneInfo(user_timezone)
+        utc_aware = ride.datetime_utc.replace(tzinfo=timezone.utc)
+        localized_datetime = utc_aware.astimezone(tz).replace(tzinfo=None)
+
+        return cls(
+            id=ride.id,
+            datetime_utc=ride.datetime_utc,
+            localized_datetime=localized_datetime,
+            type=ride.type,
+            distance=ride.distance,
+            duration=ride.duration,
+            source=ride.source,
+            avg_heart_rate=ride.avg_heart_rate,
+            deleted_at=ride.deleted_at,
+        )

--- a/fitness/models/ride.py
+++ b/fitness/models/ride.py
@@ -16,11 +16,23 @@ if TYPE_CHECKING:
 RideType = Literal["Outdoor Ride", "Indoor Ride"]
 RideSource = Literal["Strava"]
 
-# Map Strava activity types to our ride types.
-StravaRideMap: dict["StravaActivityType", RideType] = {
-    "Ride": "Outdoor Ride",
-    "VirtualRide": "Indoor Ride",
-}
+
+def _classify_strava_ride(strava_activity: "StravaActivity") -> RideType:
+    """Map a Strava cycling activity to our RideType.
+
+    Strava's `VirtualRide` is set automatically by virtual cycling apps
+    (Zwift, MyWhoosh, TrainerRoad, etc.) — it is not a user-selectable
+    type in Strava's UI. For a regular indoor trainer ride uploaded
+    directly to Strava, the convention is `type="Ride"` with the
+    `trainer` flag set to `true`. So both shapes map to "Indoor Ride".
+    """
+    if strava_activity.type == "VirtualRide":
+        return "Indoor Ride"
+    if strava_activity.type == "Ride":
+        return "Indoor Ride" if strava_activity.trainer else "Outdoor Ride"
+    raise ValueError(
+        f"Unsupported Strava activity type for Ride: {strava_activity.type!r}"
+    )
 
 
 class Ride(BaseModel):
@@ -64,7 +76,7 @@ class Ride(BaseModel):
         return cls(
             id=f"strava_{strava_activity.id}",
             datetime_utc=strava_activity.start_date.replace(tzinfo=None),
-            type=StravaRideMap[strava_activity.type],
+            type=_classify_strava_ride(strava_activity),
             distance=strava_activity.distance * 0.000621371,  # meters -> miles
             duration=strava_activity.elapsed_time,
             avg_heart_rate=strava_activity.average_heartrate,

--- a/fitness/models/ride_detail.py
+++ b/fitness/models/ride_detail.py
@@ -1,0 +1,43 @@
+"""RideDetail model — Ride enriched with Google Calendar sync status."""
+
+from __future__ import annotations
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+from fitness.models.ride import RideType, RideSource
+from fitness.models.sync import SyncStatus
+
+
+class RideDetail(BaseModel):
+    """A Ride enriched with sync status, suitable for the activity feed.
+
+    Mirrors RunDetail in shape (minus shoes / version / workout-id, which
+    rides don't carry in v1).
+    """
+
+    id: str
+    datetime_utc: datetime
+    type: RideType
+    distance: float
+    duration: float
+    source: RideSource
+    avg_heart_rate: float | None = None
+    deleted_at: datetime | None = None
+
+    # Sync info (joined from `synced_rides`).
+    is_synced: bool = False
+    sync_status: Optional[SyncStatus] = None
+    synced_at: Optional[datetime] = None
+    google_event_id: Optional[str] = None
+    synced_version: Optional[int] = None
+    error_message: Optional[str] = None
+
+    def model_dump(self, **kwargs) -> dict:
+        """Override to add a derived `date` field for parity with Run/RunDetail."""
+        data = super().model_dump(**kwargs)
+        data["date"] = (
+            self.datetime_utc.date() if self.datetime_utc is not None else None
+        )
+        return data

--- a/fitness/models/sync.py
+++ b/fitness/models/sync.py
@@ -69,6 +69,46 @@ class SyncStatusResponse(BaseModel):
     )
 
 
+class SyncedRide(BaseModel):
+    """Represents a ride that has been synced to Google Calendar."""
+
+    id: int
+    ride_id: str
+    ride_version: int = Field(
+        default=1, description="Version of the ride that was synced"
+    )
+    google_event_id: str = Field(description="Google Calendar event ID")
+    synced_at: datetime = Field(description="When the sync occurred")
+    sync_status: SyncStatus = Field(default="synced")
+    error_message: Optional[str] = Field(
+        default=None, description="Error message if sync failed"
+    )
+    created_at: datetime
+    updated_at: datetime
+
+
+class SyncRideStatusResponse(BaseModel):
+    """Response containing the sync status of a ride."""
+
+    ride_id: str = Field(description="ID of the ride")
+    is_synced: bool = Field(description="Whether the ride is currently synced")
+    sync_status: Optional[SyncStatus] = Field(
+        default=None, description="Sync status if synced"
+    )
+    synced_at: Optional[datetime] = Field(
+        default=None, description="When sync occurred if synced"
+    )
+    google_event_id: Optional[str] = Field(
+        default=None, description="Google Calendar event ID if synced"
+    )
+    ride_version: Optional[int] = Field(
+        default=None, description="Version that was synced"
+    )
+    error_message: Optional[str] = Field(
+        default=None, description="Error message if sync failed"
+    )
+
+
 class SyncedLift(BaseModel):
     """Represents a lift that has been synced to Google Calendar."""
 

--- a/fitness/utils/timezone.py
+++ b/fitness/utils/timezone.py
@@ -1,5 +1,6 @@
 """Timezone utility functions for converting between UTC and user timezones."""
 
+from collections.abc import Sequence
 from datetime import date
 
 from fitness.models import Run, LocalizedRun, Ride, LocalizedRide
@@ -64,7 +65,7 @@ def convert_rides_to_user_timezone(
 
 
 def convert_activities_to_user_timezone(
-    activities: list[Run | Ride], user_timezone: str | None = None
+    activities: Sequence[Run | Ride], user_timezone: str | None = None
 ) -> list[LocalizedRun | LocalizedRide]:
     """
     Convert a mixed list of runs and rides to the user's local timezone.

--- a/fitness/utils/timezone.py
+++ b/fitness/utils/timezone.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 
-from fitness.models import Run, LocalizedRun
+from fitness.models import Run, LocalizedRun, Ride, LocalizedRide
 
 
 def convert_runs_to_user_timezone(
@@ -15,7 +15,6 @@ def convert_runs_to_user_timezone(
     If user_timezone is None, returns LocalizedRun objects with UTC datetime as localized_datetime.
     """
     if user_timezone is None:
-        # No conversion needed - use UTC datetime as localized_datetime
         localized_runs = []
         for run in runs:
             localized_run = LocalizedRun(
@@ -37,6 +36,50 @@ def convert_runs_to_user_timezone(
     return [LocalizedRun.from_run(run, user_timezone) for run in runs]
 
 
+def convert_rides_to_user_timezone(
+    rides: list[Ride], user_timezone: str | None = None
+) -> list[LocalizedRide]:
+    """
+    Convert a list of rides to use the user's local timezone.
+
+    Mirrors convert_runs_to_user_timezone for the Ride model.
+    If user_timezone is None, returns LocalizedRide objects with UTC datetime as localized_datetime.
+    """
+    if user_timezone is None:
+        return [
+            LocalizedRide(
+                id=ride.id,
+                datetime_utc=ride.datetime_utc,
+                localized_datetime=ride.datetime_utc,
+                type=ride.type,
+                distance=ride.distance,
+                duration=ride.duration,
+                source=ride.source,
+                avg_heart_rate=ride.avg_heart_rate,
+                deleted_at=ride.deleted_at,
+            )
+            for ride in rides
+        ]
+    return [LocalizedRide.from_ride(ride, user_timezone) for ride in rides]
+
+
+def convert_activities_to_user_timezone(
+    activities: list[Run | Ride], user_timezone: str | None = None
+) -> list[LocalizedRun | LocalizedRide]:
+    """
+    Convert a mixed list of runs and rides to the user's local timezone.
+
+    Dispatches to the run- or ride-specific converter per element so each
+    activity is returned with its concrete `Localized*` type intact.
+    """
+    runs = [a for a in activities if isinstance(a, Run)]
+    rides = [a for a in activities if isinstance(a, Ride)]
+    return [
+        *convert_runs_to_user_timezone(runs, user_timezone),
+        *convert_rides_to_user_timezone(rides, user_timezone),
+    ]
+
+
 def filter_runs_by_local_date_range(
     runs: list[Run], start: date, end: date, user_timezone: str | None = None
 ) -> list[Run]:
@@ -46,10 +89,8 @@ def filter_runs_by_local_date_range(
     If user_timezone is None, uses UTC dates (existing behavior).
     """
     if user_timezone is None:
-        # Existing behavior - filter by UTC dates
         return [run for run in runs if start <= run.datetime_utc.date() <= end]
 
-    # Convert runs to user timezone and filter by local dates
     localized_runs = convert_runs_to_user_timezone(runs, user_timezone)
     return [
         localized_run

--- a/fitness/utils/timezone.py
+++ b/fitness/utils/timezone.py
@@ -70,15 +70,16 @@ def convert_activities_to_user_timezone(
     """
     Convert a mixed list of runs and rides to the user's local timezone.
 
-    Dispatches to the run- or ride-specific converter per element so each
-    activity is returned with its concrete `Localized*` type intact.
+    Dispatches per element so each activity is returned with its concrete
+    `Localized*` type intact. Preserves the input order.
     """
-    runs = [a for a in activities if isinstance(a, Run)]
-    rides = [a for a in activities if isinstance(a, Ride)]
-    return [
-        *convert_runs_to_user_timezone(runs, user_timezone),
-        *convert_rides_to_user_timezone(rides, user_timezone),
-    ]
+    result: list[LocalizedRun | LocalizedRide] = []
+    for a in activities:
+        if isinstance(a, Run):
+            result.extend(convert_runs_to_user_timezone([a], user_timezone))
+        else:
+            result.extend(convert_rides_to_user_timezone([a], user_timezone))
+    return result
 
 
 def filter_runs_by_local_date_range(

--- a/tests/_factories/__init__.py
+++ b/tests/_factories/__init__.py
@@ -1,5 +1,7 @@
 from .run import RunFactory
+from .ride import RideFactory
 from .strava_activity_with_gear import StravaActivityWithGearFactory
+from .strava_ride_activity import StravaRideActivityFactory
 from .mmf_activity import MmfActivityFactory
 from .hevy import (
     HevyWorkoutFactory,
@@ -11,7 +13,9 @@ from .lift import LiftFactory, ExerciseFactory, SetFactory, ExerciseTemplateFact
 
 __all__ = [
     "RunFactory",
+    "RideFactory",
     "StravaActivityWithGearFactory",
+    "StravaRideActivityFactory",
     "MmfActivityFactory",
     "HevyWorkoutFactory",
     "HevyExerciseFactory",

--- a/tests/_factories/ride.py
+++ b/tests/_factories/ride.py
@@ -1,0 +1,30 @@
+from typing import Any, Mapping
+from datetime import datetime
+from fitness.models import Ride
+
+
+class RideFactory:
+    def __init__(self, ride: Ride | None = None):
+        if ride is None:
+            ride = Ride(
+                id="test_ride_1",
+                datetime_utc=datetime(2024, 6, 1, 12, 0, 0),
+                type="Outdoor Ride",
+                distance=12.0,
+                duration=2700,
+                source="Strava",
+                avg_heart_rate=140.0,
+                deleted_at=None,
+            )
+        self.ride = ride
+
+    def make(self, update: Mapping[str, Any] | None = None) -> Ride:
+        ride = self.ride.model_copy(deep=True, update=update)
+        # Allow `date` shorthand mirroring RunFactory.
+        if update and "date" in update and "datetime_utc" not in update:
+            new_date = update["date"]
+            update = dict(update)
+            update["datetime_utc"] = datetime.combine(new_date, datetime.min.time())
+            del update["date"]
+            ride = self.ride.model_copy(deep=True, update=update)
+        return ride

--- a/tests/_factories/strava_ride_activity.py
+++ b/tests/_factories/strava_ride_activity.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from fitness.integrations.strava.models import StravaActivity, StravaAthlete
+
+
+class StravaRideActivityFactory:
+    """Factory for bare StravaActivity instances representing rides.
+
+    Sibling of StravaActivityWithGearFactory, but for rides — rides do not
+    track gear in v1, so the factory builds StravaActivity directly.
+    """
+
+    def __init__(self, activity: StravaActivity | None = None):
+        if activity is None:
+            activity = StravaActivity(
+                id=1001,
+                name="Test Outdoor Ride",
+                resource_state=2,
+                type="Ride",
+                commute=False,
+                start_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+                start_date_local=datetime(2024, 6, 1, tzinfo=timezone.utc),
+                timezone="UTC",
+                utc_offset=0,
+                distance=20921.5,  # ~13 miles in meters
+                moving_time=2700,
+                elapsed_time=3000,
+                total_elevation_gain=200.0,
+                has_kudoed=False,
+                has_heartrate=True,
+                athlete=StravaAthlete(id=1, resource_state=2),
+                manual=False,
+                start_latlng=[0.0, 0.0],
+                end_latlng=[0.0, 0.0],
+                achievement_count=0,
+                kudos_count=0,
+                comment_count=0,
+                athlete_count=0,
+                total_photo_count=0,
+                max_speed=12.0,
+                from_accepted_tag=False,
+                sport_type="Ride",
+                trainer=False,
+                photo_count=0,
+                private=False,
+                pr_count=0,
+                heartrate_opt_out=False,
+                average_speed=7.7,
+                visibility="everyone",
+            )
+        self.activity = activity
+
+    def make(self, update: Mapping[str, Any] | None = None) -> StravaActivity:
+        return self.activity.model_copy(deep=True, update=update)

--- a/tests/agg/test_training_load.py
+++ b/tests/agg/test_training_load.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import date
+from datetime import date, timedelta
 from fitness.agg.training_load import (
     trimp,
     threshold_trimp,
@@ -10,6 +10,7 @@ from fitness.agg.training_load import (
     _calculate_atl_and_ctl,
 )
 from tests._factories.run import RunFactory
+from tests._factories.ride import RideFactory
 
 
 class TestTrimp:
@@ -63,7 +64,7 @@ class TestTrimp:
             }
         )
 
-        with pytest.raises(ValueError, match="Run must have an average heart rate"):
+        with pytest.raises(ValueError, match="Activity must have an average heart rate"):
             trimp(run, max_hr=190, resting_hr=50, sex="M")
 
     def test_trimp_hr_clamping(self):
@@ -160,7 +161,7 @@ class TestHrtss:
                 "avg_heart_rate": None,
             }
         )
-        with pytest.raises(ValueError, match="Run must have an average heart rate"):
+        with pytest.raises(ValueError, match="Activity must have an average heart rate"):
             hrtss(run, max_hr=190, resting_hr=50, lthr=165, sex="M")
 
     def test_hrtss_zero_threshold(self):
@@ -192,7 +193,7 @@ class TestHrtssByDay:
         ]
 
         result = hrtss_by_day(
-            runs=runs,
+            activities=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 15),
             max_hr=190,
@@ -227,7 +228,7 @@ class TestHrtssByDay:
         ]
 
         result = hrtss_by_day(
-            runs=runs,
+            activities=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 15),
             max_hr=190,
@@ -262,7 +263,7 @@ class TestHrtssByDay:
         ]
 
         result = hrtss_by_day(
-            runs=runs,
+            activities=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 17),
             max_hr=190,
@@ -300,7 +301,7 @@ class TestHrtssByDay:
         ]
 
         result = hrtss_by_day(
-            runs=runs,
+            activities=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 15),
             max_hr=190,
@@ -320,7 +321,7 @@ class TestHrtssByDay:
         runs = []
 
         result = hrtss_by_day(
-            runs=runs,
+            activities=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 17),
             max_hr=190,
@@ -362,7 +363,7 @@ class TestHrtssByDay:
         ]
 
         result = hrtss_by_day(
-            runs=runs,
+            activities=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 17),
             max_hr=190,
@@ -390,7 +391,7 @@ class TestHrtssByDay:
         ]
 
         result = hrtss_by_day(
-            runs=runs,
+            activities=runs,
             start=date(2024, 1, 15),
             end=date(2024, 1, 22),
             max_hr=190,
@@ -541,7 +542,7 @@ class TestTrainingStressBalance:
         ]
 
         result = training_stress_balance(
-            runs=runs,
+            activities=runs,
             max_hr=190,
             resting_hr=50,
             lthr=165,
@@ -582,7 +583,7 @@ class TestTrainingStressBalance:
         ]
 
         result = training_stress_balance(
-            runs=runs,
+            activities=runs,
             max_hr=190,
             resting_hr=50,
             lthr=165,
@@ -599,7 +600,7 @@ class TestTrainingStressBalance:
     def test_training_stress_balance_empty_runs(self):
         """Test TSB calculation with no runs."""
         result = training_stress_balance(
-            runs=[],
+            activities=[],
             max_hr=190,
             resting_hr=50,
             lthr=165,
@@ -628,7 +629,7 @@ class TestTrainingStressBalance:
         ]
 
         result_male = training_stress_balance(
-            runs=runs,
+            activities=runs,
             max_hr=190,
             resting_hr=50,
             lthr=165,
@@ -638,7 +639,7 @@ class TestTrainingStressBalance:
         )
 
         result_female = training_stress_balance(
-            runs=runs,
+            activities=runs,
             max_hr=190,
             resting_hr=50,
             lthr=165,
@@ -673,7 +674,7 @@ class TestTrainingStressBalance:
         ]
 
         result = training_stress_balance(
-            runs=runs,
+            activities=runs,
             max_hr=190,
             resting_hr=50,
             lthr=165,
@@ -687,3 +688,149 @@ class TestTrainingStressBalance:
         # The earlier run should have affected the CTL/ATL values
         assert result[0].training_load.ctl > 0
         assert result[0].training_load.atl > 0
+
+
+class TestMixedRunsAndRides:
+    """Tests confirming runs and rides combine into a single fatigue series."""
+
+    def test_hrtss_by_day_combines_run_and_ride_same_day(self):
+        """A run and a ride on the same day should sum into one daily hrTSS value."""
+        run = RunFactory().make(
+            {"date": date(2024, 6, 1), "duration": 1800, "avg_heart_rate": 150}
+        )
+        ride = RideFactory().make(
+            {"date": date(2024, 6, 1), "duration": 2700, "avg_heart_rate": 140}
+        )
+
+        result = hrtss_by_day(
+            activities=[run, ride],
+            start=date(2024, 6, 1),
+            end=date(2024, 6, 1),
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+        )
+
+        run_only = hrtss_by_day(
+            activities=[run],
+            start=date(2024, 6, 1),
+            end=date(2024, 6, 1),
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+        )
+        ride_only = hrtss_by_day(
+            activities=[ride],
+            start=date(2024, 6, 1),
+            end=date(2024, 6, 1),
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+        )
+
+        assert len(result) == 1
+        assert result[0].hrtss == pytest.approx(
+            run_only[0].hrtss + ride_only[0].hrtss, abs=1e-6
+        )
+
+    def test_hrtss_by_day_ride_without_hr_excluded(self):
+        """Rides missing avg_heart_rate must be skipped without raising."""
+        ride_with_hr = RideFactory().make(
+            {"date": date(2024, 6, 1), "duration": 2700, "avg_heart_rate": 140}
+        )
+        ride_without_hr = RideFactory().make(
+            {
+                "id": "test_ride_2",
+                "date": date(2024, 6, 1),
+                "duration": 1800,
+                "avg_heart_rate": None,
+            }
+        )
+
+        result = hrtss_by_day(
+            activities=[ride_with_hr, ride_without_hr],
+            start=date(2024, 6, 1),
+            end=date(2024, 6, 1),
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+        )
+
+        only_with_hr = hrtss_by_day(
+            activities=[ride_with_hr],
+            start=date(2024, 6, 1),
+            end=date(2024, 6, 1),
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+        )
+        assert result[0].hrtss == pytest.approx(only_with_hr[0].hrtss, abs=1e-6)
+
+    def test_training_stress_balance_runs_only_unchanged(self):
+        """Calling with runs-only must produce the same numbers as before PR2."""
+        runs = [
+            RunFactory().make(
+                {"date": date(2024, 1, 15), "duration": 3000, "avg_heart_rate": 150}
+            ),
+            RunFactory().make(
+                {"date": date(2024, 1, 16), "duration": 2400, "avg_heart_rate": 145}
+            ),
+        ]
+        result = training_stress_balance(
+            activities=runs,
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+            start_date=date(2024, 1, 16),
+            end_date=date(2024, 1, 16),
+        )
+        assert len(result) == 1
+        # Adding a no-HR ride must not perturb the answer.
+        no_hr_ride = RideFactory().make(
+            {"date": date(2024, 1, 16), "duration": 1800, "avg_heart_rate": None}
+        )
+        result_with_no_hr_ride = training_stress_balance(
+            activities=[*runs, no_hr_ride],
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+            start_date=date(2024, 1, 16),
+            end_date=date(2024, 1, 16),
+        )
+        assert result_with_no_hr_ride[0].training_load.hrtss == pytest.approx(
+            result[0].training_load.hrtss, abs=1e-6
+        )
+
+    def test_training_stress_balance_ride_only_series(self):
+        """Rides alone should produce a non-zero fatigue series."""
+        rides = [
+            RideFactory().make(
+                {
+                    "id": f"ride_{i}",
+                    "date": date(2024, 6, 1) + timedelta(days=i),
+                    "duration": 3600,
+                    "avg_heart_rate": 145,
+                }
+            )
+            for i in range(5)
+        ]
+        result = training_stress_balance(
+            activities=rides,
+            max_hr=190,
+            resting_hr=50,
+            lthr=165,
+            sex="M",
+            start_date=date(2024, 6, 5),
+            end_date=date(2024, 6, 5),
+        )
+        assert len(result) == 1
+        assert result[0].training_load.atl > 0
+        assert result[0].training_load.ctl > 0
+        assert result[0].training_load.hrtss > 0

--- a/tests/app/ride_router/test_ride_router.py
+++ b/tests/app/ride_router/test_ride_router.py
@@ -1,0 +1,195 @@
+"""Tests for the PATCH /rides/{ride_id} endpoint."""
+
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fitness.models import Ride
+
+
+@pytest.fixture
+def outdoor_ride() -> Ride:
+    return Ride(
+        id="strava_999",
+        datetime_utc=datetime(2024, 6, 1, 14, 0, 0),
+        type="Outdoor Ride",
+        distance=12.0,
+        duration=2700,
+        source="Strava",
+        avg_heart_rate=140.0,
+    )
+
+
+@pytest.fixture
+def indoor_ride() -> Ride:
+    return Ride(
+        id="strava_1000",
+        datetime_utc=datetime(2024, 6, 2, 18, 0, 0),
+        type="Indoor Ride",
+        distance=0.0,
+        duration=3600,
+        source="Strava",
+        avg_heart_rate=145.0,
+    )
+
+
+class TestUpdateRide:
+    @patch("fitness.app.routers.ride.update_ride")
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_update_duration_and_hr(
+        self,
+        mock_get: MagicMock,
+        mock_update: MagicMock,
+        outdoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = outdoor_ride
+        updated = outdoor_ride.model_copy(
+            update={"duration": 3000.0, "avg_heart_rate": 150.0}
+        )
+        mock_update.return_value = updated
+
+        response = editor_client.patch(
+            f"/rides/{outdoor_ride.id}",
+            json={"duration": 3000, "avg_heart_rate": 150},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "success"
+        assert body["ride"]["duration"] == 3000
+        assert body["ride"]["avg_heart_rate"] == 150
+        mock_update.assert_called_once_with(
+            outdoor_ride.id, {"duration": 3000.0, "avg_heart_rate": 150.0}
+        )
+
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_404_when_ride_missing(
+        self,
+        mock_get: MagicMock,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = None
+
+        response = editor_client.patch(
+            "/rides/strava_does_not_exist",
+            json={"duration": 1800},
+        )
+        assert response.status_code == 404
+
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_400_when_no_fields(
+        self,
+        mock_get: MagicMock,
+        outdoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = outdoor_ride
+
+        response = editor_client.patch(f"/rides/{outdoor_ride.id}", json={})
+        assert response.status_code == 400
+
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_400_when_outdoor_distance_zero(
+        self,
+        mock_get: MagicMock,
+        outdoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        """Cannot leave an Outdoor Ride with distance=0."""
+        mock_get.return_value = outdoor_ride
+
+        response = editor_client.patch(
+            f"/rides/{outdoor_ride.id}",
+            json={"distance": 0},
+        )
+        assert response.status_code == 400
+        assert "distance" in response.json()["detail"].lower()
+
+    @patch("fitness.app.routers.ride.update_ride")
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_400_when_switching_to_outdoor_without_distance(
+        self,
+        mock_get: MagicMock,
+        mock_update: MagicMock,
+        indoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        """Switching Indoor → Outdoor without supplying a distance is rejected."""
+        mock_get.return_value = indoor_ride
+
+        response = editor_client.patch(
+            f"/rides/{indoor_ride.id}",
+            json={"type": "Outdoor Ride"},
+        )
+        assert response.status_code == 400
+        mock_update.assert_not_called()
+
+    @patch("fitness.app.routers.ride.update_ride")
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_switching_to_outdoor_with_distance_succeeds(
+        self,
+        mock_get: MagicMock,
+        mock_update: MagicMock,
+        indoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = indoor_ride
+        updated = indoor_ride.model_copy(
+            update={"type": "Outdoor Ride", "distance": 14.5}
+        )
+        mock_update.return_value = updated
+
+        response = editor_client.patch(
+            f"/rides/{indoor_ride.id}",
+            json={"type": "Outdoor Ride", "distance": 14.5},
+        )
+        assert response.status_code == 200
+        assert response.json()["ride"]["type"] == "Outdoor Ride"
+        assert response.json()["ride"]["distance"] == 14.5
+
+    @patch("fitness.app.routers.ride.update_ride")
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_switching_to_indoor_zeros_distance(
+        self,
+        mock_get: MagicMock,
+        mock_update: MagicMock,
+        outdoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        """Indoor Ride with distance=0 passes validation; client is responsible
+        for sending distance=0 alongside the type switch."""
+        mock_get.return_value = outdoor_ride
+        updated = outdoor_ride.model_copy(
+            update={"type": "Indoor Ride", "distance": 0.0}
+        )
+        mock_update.return_value = updated
+
+        response = editor_client.patch(
+            f"/rides/{outdoor_ride.id}",
+            json={"type": "Indoor Ride", "distance": 0},
+        )
+        assert response.status_code == 200
+        assert response.json()["ride"]["type"] == "Indoor Ride"
+        assert response.json()["ride"]["distance"] == 0
+
+    def test_requires_editor(self, viewer_client: TestClient):
+        response = viewer_client.patch("/rides/x", json={"duration": 1800})
+        assert response.status_code == 403
+
+    @patch("fitness.app.routers.ride.get_ride_by_id")
+    def test_rejects_invalid_type(
+        self,
+        mock_get: MagicMock,
+        outdoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = outdoor_ride
+
+        response = editor_client.patch(
+            f"/rides/{outdoor_ride.id}",
+            json={"type": "Outdoor Run"},
+        )
+        assert response.status_code == 422

--- a/tests/app/ride_sync_router/test_ride_sync_router.py
+++ b/tests/app/ride_sync_router/test_ride_sync_router.py
@@ -1,0 +1,208 @@
+"""Tests for /sync/rides/* endpoints."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fitness.models import Ride
+from fitness.models.sync import SyncedRide
+
+
+@pytest.fixture
+def outdoor_ride() -> Ride:
+    return Ride(
+        id="strava_ride_1",
+        datetime_utc=datetime(2024, 6, 1, 14, 0, 0),
+        type="Outdoor Ride",
+        distance=12.0,
+        duration=2700,
+        source="Strava",
+        avg_heart_rate=140.0,
+    )
+
+
+@pytest.fixture
+def indoor_ride() -> Ride:
+    return Ride(
+        id="strava_ride_2",
+        datetime_utc=datetime(2024, 6, 1, 18, 0, 0),
+        type="Indoor Ride",
+        distance=0.0,
+        duration=3600,
+        source="Strava",
+        avg_heart_rate=145.0,
+    )
+
+
+def _synced_ride_record(ride_id: str, status: str = "synced") -> SyncedRide:
+    now = datetime.now(timezone.utc)
+    return SyncedRide(
+        id=1,
+        ride_id=ride_id,
+        ride_version=1,
+        google_event_id="evt_abc123",
+        synced_at=now,
+        sync_status=status,  # type: ignore[arg-type]
+        error_message=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestSyncRide:
+    @patch("fitness.app.routers.ride_sync.create_synced_ride")
+    @patch("fitness.app.routers._sync_helpers.GoogleCalendarClient")
+    @patch("fitness.app.routers.ride_sync.get_synced_ride")
+    @patch("fitness.app.routers.ride_sync.get_ride_by_id")
+    def test_sync_outdoor_ride_creates_event_with_outdoor_title(
+        self,
+        mock_get: MagicMock,
+        mock_get_synced: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_create_record: MagicMock,
+        outdoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = outdoor_ride
+        mock_get_synced.return_value = None
+        client_instance = MagicMock()
+        client_instance.create_ride_event.return_value = "evt_abc123"
+        mock_client_cls.return_value = client_instance
+        mock_create_record.return_value = _synced_ride_record(outdoor_ride.id)
+
+        response = editor_client.post(f"/sync/rides/{outdoor_ride.id}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["google_event_id"] == "evt_abc123"
+        client_instance.create_ride_event.assert_called_once_with(outdoor_ride)
+        mock_create_record.assert_called_once()
+
+    @patch("fitness.app.routers.ride_sync.get_synced_ride")
+    @patch("fitness.app.routers.ride_sync.get_ride_by_id")
+    def test_sync_404_when_ride_missing(
+        self,
+        mock_get: MagicMock,
+        mock_get_synced: MagicMock,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = None
+        mock_get_synced.return_value = None
+        response = editor_client.post("/sync/rides/strava_missing")
+        assert response.status_code == 404
+
+    @patch("fitness.app.routers.ride_sync.get_synced_ride")
+    @patch("fitness.app.routers.ride_sync.get_ride_by_id")
+    def test_sync_already_synced_returns_no_op(
+        self,
+        mock_get: MagicMock,
+        mock_get_synced: MagicMock,
+        outdoor_ride: Ride,
+        editor_client: TestClient,
+    ):
+        mock_get.return_value = outdoor_ride
+        mock_get_synced.return_value = _synced_ride_record(outdoor_ride.id)
+
+        response = editor_client.post(f"/sync/rides/{outdoor_ride.id}")
+        assert response.status_code == 200
+        assert response.json()["success"] is False
+        assert "already synced" in response.json()["message"].lower()
+
+
+class TestUnsyncRide:
+    @patch("fitness.app.routers.ride_sync.delete_synced_ride")
+    @patch("fitness.app.routers._sync_helpers.GoogleCalendarClient")
+    @patch("fitness.app.routers.ride_sync.get_synced_ride")
+    def test_unsync_calls_calendar_delete_and_removes_record(
+        self,
+        mock_get_synced: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_delete_record: MagicMock,
+        editor_client: TestClient,
+    ):
+        mock_get_synced.return_value = _synced_ride_record("strava_ride_1")
+        client_instance = MagicMock()
+        client_instance.delete_workout_event.return_value = True
+        mock_client_cls.return_value = client_instance
+        mock_delete_record.return_value = True
+
+        response = editor_client.delete("/sync/rides/strava_ride_1")
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        client_instance.delete_workout_event.assert_called_once_with("evt_abc123")
+        mock_delete_record.assert_called_once()
+
+    @patch("fitness.app.routers.ride_sync.get_synced_ride")
+    def test_unsync_404_when_not_synced(
+        self,
+        mock_get_synced: MagicMock,
+        editor_client: TestClient,
+    ):
+        mock_get_synced.return_value = None
+        response = editor_client.delete("/sync/rides/strava_unsynced")
+        assert response.status_code == 404
+
+
+class TestSyncStatus:
+    @patch("fitness.app.routers.ride_sync.get_synced_ride")
+    def test_status_unsynced(
+        self, mock_get_synced: MagicMock, viewer_client: TestClient
+    ):
+        mock_get_synced.return_value = None
+        response = viewer_client.get("/sync/rides/strava_x/status")
+        assert response.status_code == 200
+        assert response.json()["is_synced"] is False
+
+    @patch("fitness.app.routers.ride_sync.get_synced_ride")
+    def test_status_synced(
+        self, mock_get_synced: MagicMock, viewer_client: TestClient
+    ):
+        mock_get_synced.return_value = _synced_ride_record("strava_x")
+        response = viewer_client.get("/sync/rides/strava_x/status")
+        body = response.json()
+        assert body["is_synced"] is True
+        assert body["google_event_id"] == "evt_abc123"
+
+
+def test_sync_requires_editor(viewer_client: TestClient):
+    response = viewer_client.post("/sync/rides/strava_x")
+    assert response.status_code == 403
+
+
+def test_create_ride_event_title_for_indoor(indoor_ride: Ride):
+    """Smoke-test the event title format without actually hitting Google."""
+    from fitness.integrations.google.calendar_client import GoogleCalendarClient
+
+    client = GoogleCalendarClient.__new__(GoogleCalendarClient)
+    client.base_url = "https://example.invalid"
+    client.calendar_id = "primary"
+    captured = {}
+
+    def fake_request(method, url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return MagicMock(status_code=200, json=lambda: {"id": "evt_zzz"})
+
+    client._make_request = fake_request
+    client.create_ride_event(indoor_ride)
+    assert captured["json"]["summary"] == "Indoor Bike Ride"
+
+
+def test_create_ride_event_title_for_outdoor(outdoor_ride: Ride):
+    from fitness.integrations.google.calendar_client import GoogleCalendarClient
+
+    client = GoogleCalendarClient.__new__(GoogleCalendarClient)
+    client.base_url = "https://example.invalid"
+    client.calendar_id = "primary"
+    captured = {}
+
+    def fake_request(method, url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return MagicMock(status_code=200, json=lambda: {"id": "evt_zzz"})
+
+    client._make_request = fake_request
+    client.create_ride_event(outdoor_ride)
+    assert captured["json"]["summary"] == "Outdoor Bike Ride"
+    assert "12.00 mi" in captured["json"]["description"]

--- a/tests/app/run_workouts_router/test_run_workouts.py
+++ b/tests/app/run_workouts_router/test_run_workouts.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
-from fitness.models.ride import Ride
+from fitness.models.ride_detail import RideDetail
 from fitness.models.run_workout import RunWorkout
 from fitness.models.run_detail import RunDetail
 
@@ -54,8 +54,8 @@ def _make_ride(
     type_: str = "Indoor Ride",
     duration: float = 3600.0,
     avg_heart_rate: float | None = 140.0,
-) -> Ride:
-    return Ride(
+) -> RideDetail:
+    return RideDetail(
         id=id,
         datetime_utc=datetime_utc or datetime(2024, 6, 1, 18, 0, 0),
         type=type_,  # type: ignore[arg-type]
@@ -399,12 +399,14 @@ class TestActivityFeed:
     def _stub_ride_db(self, monkeypatch):
         """Default rides to empty for every test in this class.
 
-        Individual tests can patch fitness.db.rides.get_all_rides or
-        get_rides_for_date_range to override.
+        Individual tests can patch the ride-detail queries to override.
         """
-        monkeypatch.setattr("fitness.db.rides.get_all_rides", lambda *a, **kw: [])
         monkeypatch.setattr(
-            "fitness.db.rides.get_rides_for_date_range", lambda *a, **kw: []
+            "fitness.db.rides.get_all_ride_details", lambda *a, **kw: []
+        )
+        monkeypatch.setattr(
+            "fitness.db.rides.get_ride_details_in_date_range",
+            lambda *a, **kw: [],
         )
 
     @patch("fitness.db.runs.get_all_run_details")
@@ -597,7 +599,7 @@ class TestActivityFeed:
         monkeypatch,
     ):
         monkeypatch.setattr(
-            "fitness.db.rides.get_all_rides",
+            "fitness.db.rides.get_all_ride_details",
             lambda *a, **kw: [
                 _make_ride(
                     "strava_ride_1",
@@ -627,7 +629,7 @@ class TestActivityFeed:
             _make_run_detail("run_morning", datetime(2024, 6, 1, 8, 0, 0)),
         ]
         monkeypatch.setattr(
-            "fitness.db.rides.get_all_rides",
+            "fitness.db.rides.get_all_ride_details",
             lambda *a, **kw: [
                 _make_ride("ride_evening", datetime(2024, 6, 1, 18, 0, 0)),
             ],
@@ -649,7 +651,7 @@ class TestActivityFeed:
         monkeypatch,
     ):
         monkeypatch.setattr(
-            "fitness.db.rides.get_all_rides",
+            "fitness.db.rides.get_all_ride_details",
             lambda *a, **kw: [
                 _make_ride(
                     "ride_no_hr",

--- a/tests/app/run_workouts_router/test_run_workouts.py
+++ b/tests/app/run_workouts_router/test_run_workouts.py
@@ -3,8 +3,10 @@
 from datetime import datetime
 from unittest.mock import patch, MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
+from fitness.models.ride import Ride
 from fitness.models.run_workout import RunWorkout
 from fitness.models.run_detail import RunDetail
 
@@ -43,6 +45,24 @@ def _make_workout(
         notes=notes,
         created_at=datetime(2024, 6, 1, 10, 0, 0),
         updated_at=datetime(2024, 6, 1, 10, 0, 0),
+    )
+
+
+def _make_ride(
+    id: str = "ride_1",
+    datetime_utc: datetime | None = None,
+    type_: str = "Indoor Ride",
+    duration: float = 3600.0,
+    avg_heart_rate: float | None = 140.0,
+) -> Ride:
+    return Ride(
+        id=id,
+        datetime_utc=datetime_utc or datetime(2024, 6, 1, 18, 0, 0),
+        type=type_,  # type: ignore[arg-type]
+        distance=0.0,
+        duration=duration,
+        source="Strava",
+        avg_heart_rate=avg_heart_rate,
     )
 
 
@@ -375,6 +395,18 @@ class TestSyncedWorkoutRejection:
 class TestActivityFeed:
     """Test GET /run-activity-feed."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_ride_db(self, monkeypatch):
+        """Default rides to empty for every test in this class.
+
+        Individual tests can patch fitness.db.rides.get_all_rides or
+        get_rides_for_date_range to override.
+        """
+        monkeypatch.setattr("fitness.db.rides.get_all_rides", lambda *a, **kw: [])
+        monkeypatch.setattr(
+            "fitness.db.rides.get_rides_for_date_range", lambda *a, **kw: []
+        )
+
     @patch("fitness.db.runs.get_all_run_details")
     def test_solo_runs_only(
         self,
@@ -556,3 +588,79 @@ class TestActivityFeed:
         assert ids == {"run_just_before_midnight_chicago"}, (
             f"Expected only the pre-midnight Chicago run, got {ids}"
         )
+
+    @patch("fitness.db.runs.get_all_run_details", return_value=[])
+    def test_ride_appears_as_ride_variant(
+        self,
+        _mock_get_details: MagicMock,
+        viewer_client: TestClient,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "fitness.db.rides.get_all_rides",
+            lambda *a, **kw: [
+                _make_ride(
+                    "strava_ride_1",
+                    datetime(2024, 6, 1, 18, 0, 0),
+                    type_="Indoor Ride",
+                )
+            ],
+        )
+
+        response = viewer_client.get("/run-activity-feed")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["type"] == "ride"
+        assert data[0]["item"]["id"] == "strava_ride_1"
+        assert data[0]["item"]["type"] == "Indoor Ride"
+
+    @patch("fitness.db.runs.get_all_run_details")
+    def test_ride_and_run_interleave_by_datetime_desc(
+        self,
+        mock_get_details: MagicMock,
+        viewer_client: TestClient,
+        monkeypatch,
+    ):
+        # Run at 08:00, ride at 18:00, both on the same day.
+        mock_get_details.return_value = [
+            _make_run_detail("run_morning", datetime(2024, 6, 1, 8, 0, 0)),
+        ]
+        monkeypatch.setattr(
+            "fitness.db.rides.get_all_rides",
+            lambda *a, **kw: [
+                _make_ride("ride_evening", datetime(2024, 6, 1, 18, 0, 0)),
+            ],
+        )
+
+        response = viewer_client.get("/run-activity-feed?sort_order=desc")
+        assert response.status_code == 200
+        data = response.json()
+        assert [item["item"]["id"] for item in data] == [
+            "ride_evening",
+            "run_morning",
+        ]
+
+    @patch("fitness.db.runs.get_all_run_details", return_value=[])
+    def test_ride_without_hr_still_returned(
+        self,
+        _mock_get_details: MagicMock,
+        viewer_client: TestClient,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "fitness.db.rides.get_all_rides",
+            lambda *a, **kw: [
+                _make_ride(
+                    "ride_no_hr",
+                    datetime(2024, 6, 1, 18, 0, 0),
+                    avg_heart_rate=None,
+                ),
+            ],
+        )
+
+        response = viewer_client.get("/run-activity-feed")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["item"]["avg_heart_rate"] is None

--- a/tests/app/run_workouts_router/test_run_workouts.py
+++ b/tests/app/run_workouts_router/test_run_workouts.py
@@ -1,4 +1,4 @@
-"""Test the /run-workouts and /run-activity-feed endpoints."""
+"""Test the /run-workouts and /cardio-activity-feed endpoints."""
 
 from datetime import datetime
 from unittest.mock import patch, MagicMock
@@ -393,7 +393,7 @@ class TestSyncedWorkoutRejection:
 
 
 class TestActivityFeed:
-    """Test GET /run-activity-feed."""
+    """Test GET /cardio-activity-feed."""
 
     @pytest.fixture(autouse=True)
     def _stub_ride_db(self, monkeypatch):
@@ -418,7 +418,7 @@ class TestActivityFeed:
             _make_run_detail("run_2", datetime(2024, 6, 2, 8, 0, 0)),
         ]
 
-        response = viewer_client.get("/run-activity-feed")
+        response = viewer_client.get("/cardio-activity-feed")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
@@ -449,7 +449,7 @@ class TestActivityFeed:
         ]
         mock_get_workouts.return_value = {"rw_1": _make_workout(id="rw_1")}
 
-        response = viewer_client.get("/run-activity-feed")
+        response = viewer_client.get("/cardio-activity-feed")
         assert response.status_code == 200
         data = response.json()
         # Should have 2 items: 1 solo run + 1 workout
@@ -474,7 +474,7 @@ class TestActivityFeed:
             _make_run_detail("run_2", datetime(2024, 6, 3, 8, 0, 0)),
         ]
 
-        response = viewer_client.get("/run-activity-feed?sort_order=desc")
+        response = viewer_client.get("/cardio-activity-feed?sort_order=desc")
         assert response.status_code == 200
         data = response.json()
         assert data[0]["item"]["id"] == "run_2"
@@ -491,7 +491,7 @@ class TestActivityFeed:
             _make_run_detail("run_2", datetime(2024, 6, 3, 8, 0, 0)),
         ]
 
-        response = viewer_client.get("/run-activity-feed?sort_order=asc")
+        response = viewer_client.get("/cardio-activity-feed?sort_order=asc")
         assert response.status_code == 200
         data = response.json()
         assert data[0]["item"]["id"] == "run_1"
@@ -528,7 +528,7 @@ class TestActivityFeed:
         ]
         mock_get_workouts.return_value = {"rw_1": _make_workout(id="rw_1")}
 
-        response = viewer_client.get("/run-activity-feed")
+        response = viewer_client.get("/cardio-activity-feed")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
@@ -574,7 +574,7 @@ class TestActivityFeed:
         ]
 
         response = viewer_client.get(
-            "/run-activity-feed",
+            "/cardio-activity-feed",
             params={
                 "start": "2026-04-09",
                 "end": "2026-04-09",
@@ -607,7 +607,7 @@ class TestActivityFeed:
             ],
         )
 
-        response = viewer_client.get("/run-activity-feed")
+        response = viewer_client.get("/cardio-activity-feed")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
@@ -633,7 +633,7 @@ class TestActivityFeed:
             ],
         )
 
-        response = viewer_client.get("/run-activity-feed?sort_order=desc")
+        response = viewer_client.get("/cardio-activity-feed?sort_order=desc")
         assert response.status_code == 200
         data = response.json()
         assert [item["item"]["id"] for item in data] == [
@@ -659,7 +659,7 @@ class TestActivityFeed:
             ],
         )
 
-        response = viewer_client.get("/run-activity-feed")
+        response = viewer_client.get("/cardio-activity-feed")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1

--- a/tests/app/strava_router/test_sync.py
+++ b/tests/app/strava_router/test_sync.py
@@ -5,7 +5,9 @@ from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 
 from fitness.models.run import Run
+from fitness.models.ride import Ride
 from tests._factories.strava_activity_with_gear import StravaActivityWithGearFactory
+from tests._factories.strava_ride_activity import StravaRideActivityFactory
 
 
 class TestSyncStravaData:
@@ -13,6 +15,9 @@ class TestSyncStravaData:
 
     @patch("fitness.app.routers.strava.update_last_sync_time")
     @patch("fitness.app.routers.strava.get_last_sync_time")
+    @patch("fitness.app.routers.strava.bulk_create_rides")
+    @patch("fitness.app.routers.strava.get_existing_ride_ids")
+    @patch("fitness.app.routers.strava.load_strava_rides")
     @patch("fitness.app.routers.strava.bulk_create_runs")
     @patch("fitness.app.routers.strava.get_existing_run_ids")
     @patch("fitness.app.routers.strava.load_strava_runs")
@@ -21,6 +26,9 @@ class TestSyncStravaData:
         mock_load_strava_runs: MagicMock,
         mock_get_existing_run_ids: MagicMock,
         mock_bulk_create_runs: MagicMock,
+        mock_load_strava_rides: MagicMock,
+        mock_get_existing_ride_ids: MagicMock,
+        mock_bulk_create_rides: MagicMock,
         mock_get_last_sync_time: MagicMock,
         mock_update_last_sync_time: MagicMock,
         auth_client: TestClient,
@@ -40,6 +48,10 @@ class TestSyncStravaData:
 
         # Mock bulk_create_runs to return the count of inserted runs
         mock_bulk_create_runs.return_value = 2
+
+        # No rides in this test
+        mock_load_strava_rides.return_value = []
+        mock_get_existing_ride_ids.return_value = set()
 
         # Mock sync metadata - no previous sync
         mock_get_last_sync_time.return_value = None
@@ -78,6 +90,9 @@ class TestSyncStravaData:
 
     @patch("fitness.app.routers.strava.update_last_sync_time")
     @patch("fitness.app.routers.strava.get_last_sync_time")
+    @patch("fitness.app.routers.strava.bulk_create_rides")
+    @patch("fitness.app.routers.strava.get_existing_ride_ids")
+    @patch("fitness.app.routers.strava.load_strava_rides")
     @patch("fitness.app.routers.strava.bulk_create_runs")
     @patch("fitness.app.routers.strava.get_existing_run_ids")
     @patch("fitness.app.routers.strava.load_strava_runs")
@@ -86,6 +101,9 @@ class TestSyncStravaData:
         mock_load_strava_runs: MagicMock,
         mock_get_existing_run_ids: MagicMock,
         mock_bulk_create_runs: MagicMock,
+        mock_load_strava_rides: MagicMock,
+        mock_get_existing_ride_ids: MagicMock,
+        mock_bulk_create_rides: MagicMock,
         mock_get_last_sync_time: MagicMock,
         mock_update_last_sync_time: MagicMock,
         auth_client: TestClient,
@@ -100,6 +118,10 @@ class TestSyncStravaData:
 
         # Mock get_existing_run_ids to return both runs as existing
         mock_get_existing_run_ids.return_value = {"strava_100", "strava_200"}
+
+        # No rides in this test
+        mock_load_strava_rides.return_value = []
+        mock_get_existing_ride_ids.return_value = set()
 
         # Mock sync metadata - no previous sync
         mock_get_last_sync_time.return_value = None
@@ -125,6 +147,9 @@ class TestSyncStravaData:
 
     @patch("fitness.app.routers.strava.update_last_sync_time")
     @patch("fitness.app.routers.strava.get_last_sync_time")
+    @patch("fitness.app.routers.strava.bulk_create_rides")
+    @patch("fitness.app.routers.strava.get_existing_ride_ids")
+    @patch("fitness.app.routers.strava.load_strava_rides")
     @patch("fitness.app.routers.strava.bulk_create_runs")
     @patch("fitness.app.routers.strava.get_existing_run_ids")
     @patch("fitness.app.routers.strava.load_strava_runs")
@@ -133,6 +158,9 @@ class TestSyncStravaData:
         mock_load_strava_runs: MagicMock,
         mock_get_existing_run_ids: MagicMock,
         mock_bulk_create_runs: MagicMock,
+        mock_load_strava_rides: MagicMock,
+        mock_get_existing_ride_ids: MagicMock,
+        mock_bulk_create_rides: MagicMock,
         mock_get_last_sync_time: MagicMock,
         mock_update_last_sync_time: MagicMock,
         auth_client: TestClient,
@@ -142,6 +170,8 @@ class TestSyncStravaData:
         mock_get_last_sync_time.return_value = last_sync
         mock_load_strava_runs.return_value = []
         mock_get_existing_run_ids.return_value = set()
+        mock_load_strava_rides.return_value = []
+        mock_get_existing_ride_ids.return_value = set()
 
         response = auth_client.post("/strava/sync")
 
@@ -156,6 +186,9 @@ class TestSyncStravaData:
 
     @patch("fitness.app.routers.strava.update_last_sync_time")
     @patch("fitness.app.routers.strava.get_last_sync_time")
+    @patch("fitness.app.routers.strava.bulk_create_rides")
+    @patch("fitness.app.routers.strava.get_existing_ride_ids")
+    @patch("fitness.app.routers.strava.load_strava_rides")
     @patch("fitness.app.routers.strava.bulk_create_runs")
     @patch("fitness.app.routers.strava.get_existing_run_ids")
     @patch("fitness.app.routers.strava.load_strava_runs")
@@ -164,6 +197,9 @@ class TestSyncStravaData:
         mock_load_strava_runs: MagicMock,
         mock_get_existing_run_ids: MagicMock,
         mock_bulk_create_runs: MagicMock,
+        mock_load_strava_rides: MagicMock,
+        mock_get_existing_ride_ids: MagicMock,
+        mock_bulk_create_rides: MagicMock,
         mock_get_last_sync_time: MagicMock,
         mock_update_last_sync_time: MagicMock,
         auth_client: TestClient,
@@ -173,6 +209,8 @@ class TestSyncStravaData:
         mock_get_last_sync_time.return_value = last_sync
         mock_load_strava_runs.return_value = []
         mock_get_existing_run_ids.return_value = set()
+        mock_load_strava_rides.return_value = []
+        mock_get_existing_ride_ids.return_value = set()
 
         response = auth_client.post("/strava/sync?full_sync=true")
 
@@ -187,3 +225,93 @@ class TestSyncStravaData:
 
         # get_last_sync_time should NOT be called when full_sync=true
         mock_get_last_sync_time.assert_not_called()
+
+    @patch("fitness.app.routers.strava.update_last_sync_time")
+    @patch("fitness.app.routers.strava.get_last_sync_time")
+    @patch("fitness.app.routers.strava.bulk_create_rides")
+    @patch("fitness.app.routers.strava.get_existing_ride_ids")
+    @patch("fitness.app.routers.strava.load_strava_rides")
+    @patch("fitness.app.routers.strava.bulk_create_runs")
+    @patch("fitness.app.routers.strava.get_existing_run_ids")
+    @patch("fitness.app.routers.strava.load_strava_runs")
+    def test_sync_inserts_runs_and_rides_together(
+        self,
+        mock_load_strava_runs: MagicMock,
+        mock_get_existing_run_ids: MagicMock,
+        mock_bulk_create_runs: MagicMock,
+        mock_load_strava_rides: MagicMock,
+        mock_get_existing_ride_ids: MagicMock,
+        mock_bulk_create_rides: MagicMock,
+        mock_get_last_sync_time: MagicMock,
+        mock_update_last_sync_time: MagicMock,
+        auth_client: TestClient,
+    ):
+        """Sync should ingest runs and rides in the same call."""
+        run_factory = StravaActivityWithGearFactory()
+        ride_factory = StravaRideActivityFactory()
+
+        mock_load_strava_runs.return_value = [run_factory.make({"id": 100})]
+        mock_get_existing_run_ids.return_value = set()
+        mock_bulk_create_runs.return_value = 1
+
+        mock_load_strava_rides.return_value = [
+            ride_factory.make({"id": 500}),
+            ride_factory.make({"id": 600, "type": "VirtualRide", "trainer": True}),
+        ]
+        mock_get_existing_ride_ids.return_value = set()
+        mock_bulk_create_rides.return_value = 2
+
+        mock_get_last_sync_time.return_value = None
+
+        response = auth_client.post("/strava/sync")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["inserted_count"] == 3  # 1 run + 2 rides
+        assert data["inserted_runs"] == 1
+        assert data["inserted_rides"] == 2
+
+        # Both bulk creators were called with the right model types
+        run_arg = mock_bulk_create_runs.call_args[0][0]
+        ride_arg = mock_bulk_create_rides.call_args[0][0]
+        assert all(isinstance(r, Run) for r in run_arg)
+        assert all(isinstance(r, Ride) for r in ride_arg)
+        assert {r.type for r in ride_arg} == {"Outdoor Ride", "Indoor Ride"}
+
+    @patch("fitness.app.routers.strava.update_last_sync_time")
+    @patch("fitness.app.routers.strava.get_last_sync_time")
+    @patch("fitness.app.routers.strava.bulk_create_rides")
+    @patch("fitness.app.routers.strava.get_existing_ride_ids")
+    @patch("fitness.app.routers.strava.load_strava_rides")
+    @patch("fitness.app.routers.strava.bulk_create_runs")
+    @patch("fitness.app.routers.strava.get_existing_run_ids")
+    @patch("fitness.app.routers.strava.load_strava_runs")
+    def test_sync_dedupes_existing_rides(
+        self,
+        mock_load_strava_runs: MagicMock,
+        mock_get_existing_run_ids: MagicMock,
+        mock_bulk_create_runs: MagicMock,
+        mock_load_strava_rides: MagicMock,
+        mock_get_existing_ride_ids: MagicMock,
+        mock_bulk_create_rides: MagicMock,
+        mock_get_last_sync_time: MagicMock,
+        mock_update_last_sync_time: MagicMock,
+        auth_client: TestClient,
+    ):
+        """Existing ride IDs should be filtered out before bulk insert."""
+        ride_factory = StravaRideActivityFactory()
+        mock_load_strava_runs.return_value = []
+        mock_get_existing_run_ids.return_value = set()
+        mock_load_strava_rides.return_value = [
+            ride_factory.make({"id": 700}),
+            ride_factory.make({"id": 800}),
+        ]
+        mock_get_existing_ride_ids.return_value = {"strava_700"}
+        mock_bulk_create_rides.return_value = 1
+        mock_get_last_sync_time.return_value = None
+
+        response = auth_client.post("/strava/sync")
+
+        assert response.status_code == 200
+        new_rides = mock_bulk_create_rides.call_args[0][0]
+        assert {r.id for r in new_rides} == {"strava_800"}

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -25,6 +25,11 @@ class TestAuthenticationEndpoints:
             )
             m.setattr("fitness.app.routers.strava.get_existing_run_ids", lambda: [])
             m.setattr(
+                "fitness.app.routers.strava.load_strava_rides",
+                lambda client, after=None: [],
+            )
+            m.setattr("fitness.app.routers.strava.get_existing_ride_ids", lambda: [])
+            m.setattr(
                 "fitness.app.routers.strava.get_last_sync_time", lambda provider: None
             )
             m.setattr(

--- a/tests/app/test_date_range_queries.py
+++ b/tests/app/test_date_range_queries.py
@@ -114,9 +114,11 @@ def test_rolling_mileage_includes_lookback_window(
 
 def test_training_load_uses_all_runs(monkeypatch, viewer_client: TestClient):
     """Training load needs full history for ATL/CTL convergence, not date-filtered."""
-    mock_all = MagicMock(return_value=[])
+    mock_all_runs = MagicMock(return_value=[])
+    mock_all_rides = MagicMock(return_value=[])
     mock_date_range = MagicMock(return_value=[])
-    monkeypatch.setattr("fitness.app.routers.metrics.get_all_runs", mock_all)
+    monkeypatch.setattr("fitness.app.routers.metrics.get_all_runs", mock_all_runs)
+    monkeypatch.setattr("fitness.app.routers.metrics.get_all_rides", mock_all_rides)
     monkeypatch.setattr(
         "fitness.app.routers.metrics.get_runs_for_date_range", mock_date_range
     )
@@ -133,5 +135,6 @@ def test_training_load_uses_all_runs(monkeypatch, viewer_client: TestClient):
         },
     )
 
-    mock_all.assert_called_once()
+    mock_all_runs.assert_called_once()
+    mock_all_rides.assert_called_once()
     mock_date_range.assert_not_called()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,13 @@
 import pytest
 from fitness.app import env_loader  # noqa: F401
 
-from ._factories import RunFactory, StravaActivityWithGearFactory, MmfActivityFactory
+from ._factories import (
+    RunFactory,
+    RideFactory,
+    StravaActivityWithGearFactory,
+    StravaRideActivityFactory,
+    MmfActivityFactory,
+)
 
 
 class AccidentalDatabaseAccessError(Exception):
@@ -47,8 +53,18 @@ def run_factory() -> RunFactory:
 
 
 @pytest.fixture(scope="session")
+def ride_factory() -> RideFactory:
+    return RideFactory()
+
+
+@pytest.fixture(scope="session")
 def strava_activity_with_gear_factory() -> StravaActivityWithGearFactory:
     return StravaActivityWithGearFactory()
+
+
+@pytest.fixture(scope="session")
+def strava_ride_activity_factory() -> StravaRideActivityFactory:
+    return StravaRideActivityFactory()
 
 
 @pytest.fixture(scope="session")

--- a/tests/db/test_rides.py
+++ b/tests/db/test_rides.py
@@ -1,0 +1,82 @@
+"""Tests for rides database operations."""
+
+from datetime import date, datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from fitness.models import Ride
+from fitness.db.rides import (
+    bulk_create_rides,
+    get_existing_ride_ids,
+    get_rides_for_date_range,
+)
+
+
+@pytest.fixture
+def sample_ride():
+    return Ride(
+        id="strava_999",
+        datetime_utc=datetime(2024, 6, 1, 14, 0, 0),
+        type="Outdoor Ride",
+        distance=12.0,
+        duration=2700,
+        source="Strava",
+        avg_heart_rate=140.0,
+    )
+
+
+class TestBulkCreateRides:
+    @patch("fitness.db.rides.get_db_connection")
+    def test_returns_zero_for_empty_input(self, mock_get_conn):
+        assert bulk_create_rides([]) == 0
+        mock_get_conn.assert_not_called()
+
+    @patch("fitness.db.rides.get_db_connection")
+    def test_inserts_into_rides_table(self, mock_get_conn, sample_ride):
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 1
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_get_conn.return_value.__enter__.return_value = mock_conn
+
+        inserted = bulk_create_rides([sample_ride])
+
+        assert inserted == 1
+        # The cursor should have run executemany once with an INSERT INTO rides
+        mock_cursor.executemany.assert_called_once()
+        call_args = mock_cursor.executemany.call_args
+        assert "INSERT INTO rides" in call_args[0][0]
+        # No history table interaction (rides have no history table in v1)
+        assert "rides_history" not in call_args[0][0]
+
+
+class TestGetExistingRideIds:
+    @patch("fitness.db.rides.get_db_cursor")
+    def test_returns_set_of_ids_excluding_deleted(self, mock_get_cursor):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [("strava_1",), ("strava_2",)]
+        mock_get_cursor.return_value.__enter__.return_value = mock_cursor
+
+        result = get_existing_ride_ids()
+
+        assert result == {"strava_1", "strava_2"}
+        executed_sql = mock_cursor.execute.call_args[0][0]
+        assert "deleted_at IS NULL" in executed_sql
+
+
+class TestGetRidesForDateRange:
+    @patch("fitness.db.rides.get_rides_in_date_range", return_value=[])
+    def test_widens_with_timezone(self, mock_db):
+        get_rides_for_date_range(date(2025, 6, 1), date(2025, 6, 30), "America/New_York")
+        mock_db.assert_called_once_with(date(2025, 5, 31), date(2025, 7, 1))
+
+    @patch("fitness.db.rides.get_rides_in_date_range", return_value=[])
+    def test_exact_without_timezone(self, mock_db):
+        get_rides_for_date_range(date(2025, 6, 1), date(2025, 6, 30), None)
+        mock_db.assert_called_once_with(date(2025, 6, 1), date(2025, 6, 30))
+
+    @patch("fitness.db.rides.get_rides_in_date_range", return_value=[])
+    def test_defaults_to_no_timezone(self, mock_db):
+        get_rides_for_date_range(date(2025, 6, 1), date(2025, 6, 30))
+        mock_db.assert_called_once_with(date(2025, 6, 1), date(2025, 6, 30))

--- a/tests/models/test_ride.py
+++ b/tests/models/test_ride.py
@@ -46,6 +46,30 @@ def test_ride_from_strava_virtual(
     assert ride.avg_heart_rate == 158.0
 
 
+def test_ride_from_strava_trainer_ride_classified_indoor(
+    strava_ride_activity_factory: StravaRideActivityFactory,
+):
+    """Strava's VirtualRide type is set automatically by Zwift/etc.; manually
+    uploaded indoor rides come in as type='Ride' with trainer=True. Both
+    shapes must classify as 'Indoor Ride'."""
+    activity = strava_ride_activity_factory.make(
+        update={"type": "Ride", "trainer": True, "average_heartrate": 150.0}
+    )
+    ride = Ride.from_strava(activity)
+    assert ride.type == "Indoor Ride"
+
+
+def test_ride_from_strava_outdoor_explicit_no_trainer(
+    strava_ride_activity_factory: StravaRideActivityFactory,
+):
+    """Confirm trainer=False on a regular Ride still maps to Outdoor Ride."""
+    activity = strava_ride_activity_factory.make(
+        update={"type": "Ride", "trainer": False, "average_heartrate": 145.0}
+    )
+    ride = Ride.from_strava(activity)
+    assert ride.type == "Outdoor Ride"
+
+
 def test_ride_from_strava_no_heartrate(
     strava_ride_activity_factory: StravaRideActivityFactory,
 ):

--- a/tests/models/test_ride.py
+++ b/tests/models/test_ride.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from fitness.models import Ride, LocalizedRide
+from tests._factories import StravaRideActivityFactory
+
+
+def test_ride_from_strava_outdoor(
+    strava_ride_activity_factory: StravaRideActivityFactory,
+):
+    activity = strava_ride_activity_factory.make(
+        update={
+            "start_date": datetime(2024, 11, 4, tzinfo=timezone.utc),
+            "type": "Ride",
+            "distance": 16093.4,  # 10 miles in meters
+            "moving_time": 1700,
+            "elapsed_time": 1800,
+            "average_heartrate": 142.0,
+        }
+    )
+    ride = Ride.from_strava(activity)
+    assert ride.datetime_utc == datetime(2024, 11, 4)
+    assert ride.type == "Outdoor Ride"
+    assert ride.distance == pytest.approx(10, rel=1e-4)
+    assert ride.duration == 1800  # elapsed_time, parity with Run
+    assert ride.avg_heart_rate == 142.0
+    assert ride.source == "Strava"
+    assert ride.id == f"strava_{activity.id}"
+    assert ride.deleted_at is None
+
+
+def test_ride_from_strava_virtual(
+    strava_ride_activity_factory: StravaRideActivityFactory,
+):
+    activity = strava_ride_activity_factory.make(
+        update={
+            "type": "VirtualRide",
+            "trainer": True,
+            "average_heartrate": 158.0,
+        }
+    )
+    ride = Ride.from_strava(activity)
+    assert ride.type == "Indoor Ride"
+    assert ride.avg_heart_rate == 158.0
+
+
+def test_ride_from_strava_no_heartrate(
+    strava_ride_activity_factory: StravaRideActivityFactory,
+):
+    activity = strava_ride_activity_factory.make(
+        update={"average_heartrate": None}
+    )
+    ride = Ride.from_strava(activity)
+    assert ride.avg_heart_rate is None
+
+
+def test_ride_rejects_invalid_type():
+    with pytest.raises(ValidationError):
+        Ride(
+            id="strava_1",
+            datetime_utc=datetime(2024, 1, 1),
+            type="Outdoor Run",  # type: ignore[arg-type]
+            distance=10.0,
+            duration=1800,
+            source="Strava",
+        )
+
+
+def test_localized_ride_from_ride():
+    ride = Ride(
+        id="strava_1",
+        datetime_utc=datetime(2024, 6, 1, 14, 0),  # 14:00 UTC
+        type="Outdoor Ride",
+        distance=10.0,
+        duration=1800,
+        source="Strava",
+        avg_heart_rate=140.0,
+    )
+    localized = LocalizedRide.from_ride(ride, "America/Chicago")
+    # 14:00 UTC = 09:00 CDT (CST is -6, CDT is -5; June -> CDT)
+    assert localized.localized_datetime.hour == 9
+    assert localized.local_date == ride.datetime_utc.date()
+    assert localized.id == ride.id
+    assert localized.avg_heart_rate == 140.0
+
+
+def test_ride_soft_delete_and_restore():
+    ride = Ride(
+        id="strava_1",
+        datetime_utc=datetime(2024, 1, 1),
+        type="Outdoor Ride",
+        distance=5.0,
+        duration=900,
+        source="Strava",
+    )
+    assert ride.is_deleted is False
+    ride.soft_delete()
+    assert ride.is_deleted is True
+    assert ride.deleted_at is not None
+    ride.restore()
+    assert ride.is_deleted is False
+    assert ride.deleted_at is None


### PR DESCRIPTION
## Summary
- Ingest Strava `Ride` (outdoor) and `VirtualRide` (indoor trainer) activities into a new `rides` table parallel to `runs`.
- Combine runs + rides into a single ATL/CTL/TSB/hrTSS series; the existing freshness chart and activity calendar pick up rides automatically.
- Generalize `training_stress_balance` and `hrtss_by_day` to accept `Run | Ride` (param renamed `runs` → `activities`); `trimp` / `hrtss` widened the same way.
- `/strava/sync` ingests both in one request; response gains optional `inserted_runs` / `inserted_rides` while `inserted_count` stays as the backward-compatible sum.

## Scope (intentionally minimal)
- **No `/rides` UI** in this PR. Dashboard surfaces rides only via the freshness chart + activity calendar (the two API endpoints they consume now combine both).
- **No bike-gear tracking** — rides skip the gear lookup; `bike_id` deferred to v2.
- Ride duration uses `elapsed_time` for parity with runs.
- E-bikes (`EBikeRide`) are not ingested; `StravaActivityType` only gains `VirtualRide`.

## Pre-existing issues observed but explicitly deferred
- Gear-drop bug in `load_strava_runs` (filed separately).
- Soft-delete dedup hole in `get_existing_run_ids` — `get_existing_ride_ids` mirrors the same behavior so the fix can land for both later.

## After deploy
1. `alembic upgrade head` — creates `rides` table.
2. One-time `POST /strava/sync?full_sync=true` to backfill historical rides (incremental sync uses the existing `last_sync_time` for provider `strava`, so historical rides won't appear without a full sync).

## Companion PR
- eswan18/fitness-dashboard#TBD adds the optional response fields to the frontend type. Functionally a no-op without this backend PR.

## Test plan
- [x] `uv run pytest --ignore=tests/e2e` — 378 unit tests pass.
- [x] `uv run ruff check fitness tests` — clean.
- [ ] Run `alembic upgrade head` against staging.
- [ ] `POST /strava/sync?full_sync=true` against staging — confirm response includes `inserted_rides > 0` and rows for both `Outdoor Ride` and `Indoor Ride` types appear.
- [ ] Spot-check `/metrics/training-load/by-day` — hrTSS values should increase on ride days vs. pre-PR baseline.
- [ ] Open dashboard `/dashboard/runs` — freshness chart and activity calendar reflect ride load; `/runs` page is unchanged.
- [ ] Confirm a ride without HR is stored but does not contribute to `/metrics/hrtss/by-day`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)